### PR TITLE
SK-507 uploadfiles method is giving response status 200 even though we have not selected any file for required field

### DIFF
--- a/src/utils/helpers/index.ts
+++ b/src/utils/helpers/index.ts
@@ -100,7 +100,10 @@ export const handleCopyIconClick = (textToCopy: string, domCopy: any) => {
 const DANGEROUS_FILE_TYPE = ['application/zip', 'application/vnd.debian.binary-package', 'application/vnd.microsoft.portable-executable', 'application/vnd.rar'];
 // Check file type and file size in KB
 export const fileValidation = (value) => {
-  if (value === undefined) return true;
+  if (value === undefined || value === '') {
+    return false;
+  }
+
   if (DANGEROUS_FILE_TYPE.includes(value.type) || value.size > 3200000) return false;
   return true;
 };


### PR DESCRIPTION
## Fix Issue with File Upload in JS SDK

 - `FILE_INPUT` element was returning success response with `200` status code even when file was **required** and was **NOT** provided.
 - Updated the validator method and added validation for empty file input.