### PR TITLE
SK-553 Fixed Validation for File Input

### DIFF
--- a/src/core/internal/iframe-form/index.ts
+++ b/src/core/internal/iframe-form/index.ts
@@ -367,7 +367,7 @@ export class IFrameFormElement extends EventEmitter {
       resp = validateExpiryYear(value, this.format);
     } else if (this.fieldType === ElementType.FILE_INPUT) {
       try {
-        resp = fileValidation(value);
+        resp = fileValidation(value, this.state.isRequired);
       } catch (err) {
         resp = false;
       }
@@ -837,12 +837,12 @@ export class IFrameForm {
     }
 
     try {
-      fileValidation(state.value);
+      fileValidation(state.value, state.isRequired);
     } catch (err) {
       return Promise.reject(err);
     }
 
-    const validatedFileState = fileValidation(state.value);
+    const validatedFileState = fileValidation(state.value, state.isRequired);
 
     if (!validatedFileState) {
       return Promise.reject(new SkyflowError(SKYFLOW_ERROR_CODE.INVALID_FILE_TYPE, [], true));

--- a/src/utils/helpers/index.ts
+++ b/src/utils/helpers/index.ts
@@ -103,8 +103,8 @@ export const handleCopyIconClick = (textToCopy: string, domCopy: any) => {
 
 const DANGEROUS_FILE_TYPE = ['application/zip', 'application/vnd.debian.binary-package', 'application/vnd.microsoft.portable-executable', 'application/vnd.rar'];
 // Check file type and file size in KB
-export const fileValidation = (value) => {
-  if (value === undefined || value === '') {
+export const fileValidation = (value, required: Boolean = false) => {
+  if (required && (value === undefined || value === '')) {
     throw new SkyflowError(SKYFLOW_ERROR_CODE.NO_FILE_SELECTED, [], true);
   }
 

--- a/tests/utils/helpers.test.js
+++ b/tests/utils/helpers.test.js
@@ -156,8 +156,14 @@ describe('test file validation', () => {
   })
   test('no file selected', () => {
     const file = {}
+      const isValid = fileValidation(file);
+      expect(isValid).toBe(true);
+  })
+
+  test('no file selected for required file input', () => {
+    const file = {}
     try {
-      fileValidation(file);
+      fileValidation(file, true);
     } catch(err) {
       expect(err?.error?.description).toEqual(SKYFLOW_ERROR_CODE.NO_FILE_SELECTED.description)
     }


### PR DESCRIPTION
## Fixed Validation for File Input

- Worked on Bug [SK-553](https://skyflow.atlassian.net/browse/SK-553)
- Only for required file type, no file selected validation will trigger
- Added unit test case to test the scenario

[SK-553]: https://skyflow.atlassian.net/browse/SK-553?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ