### PR TITLE
SK-1842: Config embedded in URL for iframes

### DIFF
--- a/src/core/external/collect/collect-container.ts
+++ b/src/core/external/collect/collect-container.ts
@@ -284,6 +284,8 @@ class CollectContainer extends Container {
     try {
       validateInitConfig(this.#metaData.clientJSON.config);
       const collectElements = Object.values(this.#elements);
+      const elementIds = Object.keys(this.#elements)
+        .map((element) => ({ frameId: element, elementId: element }));
       collectElements.forEach((element) => {
         if (!element.isMounted()) {
           throw new SkyflowError(SKYFLOW_ERROR_CODE.ELEMENTS_NOT_MOUNTED, [], true);
@@ -306,6 +308,7 @@ class CollectContainer extends Container {
           {
             ...options,
             tokens: options?.tokens !== undefined ? options.tokens : true,
+            elementIds,
           },
           (data: any) => {
             if (!data || data?.error) {

--- a/src/core/external/collect/collect-element.ts
+++ b/src/core/external/collect/collect-element.ts
@@ -246,12 +246,16 @@ class CollectElement extends SkyflowElement {
 
     const isComposable = this.#elements.length > 1;
     if (isComposable) {
-      this.#iframe.mount(domElement, this.#elementId);
+      this.#iframe.mount(domElement, this.#elementId, {
+        record: JSON.stringify({ record: this.#group }),
+      });
       this.#bus.on(ELEMENT_EVENTS_TO_IFRAME.FRAME_READY + this.containerId, sub);
       updateMetricObjectValue(this.#elementId, METRIC_TYPES.MOUNT_START_TIME, Date.now());
     } else {
       if (this.#readyToMount) {
-        this.#iframe.mount(domElement, this.#elementId);
+        this.#iframe.mount(domElement, this.#elementId, {
+          record: JSON.stringify({ record: this.#group }),
+        });
         this.#bus.on(ELEMENT_EVENTS_TO_IFRAME.FRAME_READY + this.containerId, sub);
         updateMetricObjectValue(this.#elementId, METRIC_TYPES.MOUNT_START_TIME, Date.now());
         return;
@@ -259,7 +263,9 @@ class CollectElement extends SkyflowElement {
       this.#groupEmitter?.on(ELEMENT_EVENTS_TO_CONTAINER.COLLECT_CONTAINER_MOUNTED, (data) => {
         if (data?.containerId === this.containerId) {
           updateMetricObjectValue(this.#elementId, METRIC_TYPES.MOUNT_START_TIME, Date.now());
-          this.#iframe.mount(domElement, this.#elementId);
+          this.#iframe.mount(domElement, this.#elementId, {
+            record: JSON.stringify({ record: this.#group }),
+          });
           this.#bus.on(ELEMENT_EVENTS_TO_IFRAME.FRAME_READY + this.containerId, sub);
         }
       });

--- a/src/core/external/collect/compose-collect-container.ts
+++ b/src/core/external/collect/compose-collect-container.ts
@@ -369,7 +369,7 @@ class ComposableContainer extends Container {
           throw new SkyflowError(SKYFLOW_ERROR_CODE.ELEMENTS_NOT_MOUNTED, [], true);
         }
       });
-
+      const elementIds:{ frameId:string, elementId:string }[] = [];
       const collectElements = Object.values(this.#elements);
       collectElements.forEach((element) => {
         element.isValidElement();
@@ -384,6 +384,12 @@ class ComposableContainer extends Container {
       if (options?.upsert) {
         validateUpsertOptions(options?.upsert);
       }
+      this.#elementsList.forEach((element) => {
+        elementIds.push({
+          frameId: this.#tempElements.elementName,
+          elementId: element.elementName,
+        });
+      });
       bus
       // .target(properties.IFRAME_SECURE_ORIGIN)
         .emit(
@@ -391,6 +397,7 @@ class ComposableContainer extends Container {
           {
             ...options,
             tokens: options?.tokens !== undefined ? options.tokens : true,
+            elementIds,
           },
           (data: any) => {
             if (!data || data?.error) {

--- a/src/core/external/common/iframe.ts
+++ b/src/core/external/common/iframe.ts
@@ -29,7 +29,7 @@ export default class IFrame {
     });
   }
 
-  mount = (domElement, elementId?: string) => {
+  mount = (domElement, elementId?: string, data?: any) => {
     this.unmount();
     try {
       if (typeof domElement === 'string') {
@@ -49,7 +49,7 @@ export default class IFrame {
       // throw new SkyflowError(SKYFLOW_ERROR_CODE.INVALID_ELEMENT_SELECTOR, [], true);
     }
 
-    setAttributes(this.iframe, { src: getIframeSrc() });
+    setAttributes(this.iframe, { src: `${getIframeSrc()}${data ? `?${btoa(data?.record)}` : ''}` });
 
     this.container?.appendChild(this.iframe);
   };

--- a/src/core/external/reveal/reveal-element.ts
+++ b/src/core/external/reveal/reveal-element.ts
@@ -156,7 +156,13 @@ class RevealElement extends SkyflowElement {
     };
 
     if (this.#readyToMount) {
-      this.#iframe.mount(domElementSelector);
+      this.#iframe.mount(domElementSelector, undefined, {
+        record: JSON.stringify({
+          ...this.#metaData,
+          record: this.#recordData,
+          context: this.#context,
+        }),
+      });
       bus
         .target(properties.IFRAME_SECURE_ORIGIN)
         .on(ELEMENT_EVENTS_TO_IFRAME.REVEAL_FRAME_READY, sub);
@@ -166,7 +172,13 @@ class RevealElement extends SkyflowElement {
     }
     this.#eventEmitter?.on(ELEMENT_EVENTS_TO_CONTAINER.REVEAL_CONTAINER_MOUNTED, (data) => {
       if (data?.containerId === this.#containerId) {
-        this.#iframe.mount(domElementSelector);
+        this.#iframe.mount(domElementSelector, undefined, {
+          record: JSON.stringify({
+            ...this.#metaData,
+            record: this.#recordData,
+            context: this.#context,
+          }),
+        });
         bus
           .target(properties.IFRAME_SECURE_ORIGIN)
           .on(ELEMENT_EVENTS_TO_IFRAME.REVEAL_FRAME_READY, sub);

--- a/src/core/internal/frame-elements.ts
+++ b/src/core/internal/frame-elements.ts
@@ -64,11 +64,15 @@ export default class FrameElements {
     bus.emit(
       ELEMENT_EVENTS_TO_IFRAME.FRAME_READY + getValueFromName(frameName, 3),
       { name: frameName },
-      (group: any) => {
+      () => {
         printLog(parameterizedString(logs.infoLogs.COLLECT_FRAME_READY_CB,
           CLASS_NAME, getElementName(frameName)), MessageType.LOG,
         logLevel);
-        FrameElements.group = group;
+        const url = window.location?.href;
+        const configIndex = url.indexOf('?');
+        const encodedString = configIndex !== -1 ? decodeURIComponent(url.substring(configIndex + 1)) : '';
+        const parsedRecord = encodedString ? JSON.parse(atob(encodedString)) : {};
+        FrameElements.group = parsedRecord?.record;
         if (FrameElements.frameElements) {
           printLog(parameterizedString(logs.infoLogs.SETUP_IN_START, CLASS_NAME),
             MessageType.LOG, logLevel);

--- a/src/core/internal/iframe-form/index.ts
+++ b/src/core/internal/iframe-form/index.ts
@@ -29,6 +29,7 @@ import {
 } from '../../../utils/validators';
 import {
   checkForElementMatchRule,
+  checkForValueMatch,
   constructElementsInsertReq,
   constructInsertRecordRequest,
   constructInsertRecordResponse,
@@ -1046,9 +1047,16 @@ export class IFrameForm {
           !== ELEMENTS.FILE_INPUT.name
         ) {
           const {
-            state, doesClientHasError, clientErrorText, errorText, onFocusChange,
+            state, doesClientHasError, clientErrorText, errorText, onFocusChange, validations,
+            setValue,
           } = inputElement.iFrameFormElement;
           if (state.isRequired || !state.isValid) {
+            onFocusChange(false);
+          }
+          if (validations
+            && checkForElementMatchRule(validations)
+            && checkForValueMatch(validations, inputElement.iFrameFormElement)) {
+            setValue(state.value);
             onFocusChange(false);
           }
           if (!state.isValid || !state.isComplete) {

--- a/src/core/internal/iframe-form/index.ts
+++ b/src/core/internal/iframe-form/index.ts
@@ -1036,33 +1036,27 @@ export class IFrameForm {
     if (!this.client) throw new SkyflowError(SKYFLOW_ERROR_CODE.CLIENT_CONNECTION, [], true);
     const insertResponseObject: any = {};
     const updateResponseObject: any = {};
-    const formElements = Object.keys(this.iFrameFormElements);
     let errorMessage = '';
-    for (let i = 0; i < formElements.length; i += 1) {
-      if (
-        this.iFrameFormElements[formElements[i]].fieldType
-        !== ELEMENTS.FILE_INPUT.name
-      ) {
-        const {
-          state, doesClientHasError, clientErrorText, errorText, onFocusChange,
-          validations, setValue,
-        } = this.iFrameFormElements[formElements[i]];
-
-        if (state.isRequired || !state.isValid) {
-          onFocusChange(false);
-        }
-
-        if (validations
-          && checkForElementMatchRule(validations)
-          && checkForValueMatch(validations, this.iFrameFormElements[formElements[i]])) {
-          setValue(state.value);
-          onFocusChange(false);
-        }
-
-        if (!state.isValid || !state.isComplete) {
-          if (doesClientHasError) {
-            errorMessage += `${state.name}:${clientErrorText}`;
-          } else { errorMessage += `${state.name}:${errorText} `; }
+    for (let i = 0; i < options.elementIds.length; i += 1) {
+      const Frame = window.parent.frames[`${options.elementIds[i].frameId}:${this.controllerId}:${this.logLevel}`];
+      const inputElement = Frame.document
+        .getElementById(options.elementIds[i].elementId);
+      if (inputElement) {
+        if (
+          inputElement.iFrameFormElement.fieldType
+          !== ELEMENTS.FILE_INPUT.name
+        ) {
+          const {
+            state, doesClientHasError, clientErrorText, errorText, onFocusChange,
+          } = inputElement.iFrameFormElement;
+          if (state.isRequired || !state.isValid) {
+            onFocusChange(false);
+          }
+          if (!state.isValid || !state.isComplete) {
+            if (doesClientHasError) {
+              errorMessage += `${state.name}:${clientErrorText}`;
+            } else { errorMessage += `${state.name}:${errorText} `; }
+          }
         }
       }
     }
@@ -1071,69 +1065,73 @@ export class IFrameForm {
       return Promise.reject(new SkyflowError(SKYFLOW_ERROR_CODE.COMPLETE_AND_VALID_INPUTS, [`${errorMessage}`], true));
     }
 
-    for (let i = 0; i < formElements.length; i += 1) {
-      const {
-        state, tableName, validations, skyflowID,
-      } = this.iFrameFormElements[formElements[i]];
-      if (tableName) {
-        if (
-          this.iFrameFormElements[formElements[i]].fieldType
-        !== ELEMENTS.FILE_INPUT.name
-        ) {
+    for (let i = 0; i < options.elementIds.length; i += 1) {
+      const Frame = window.parent.frames[`${options.elementIds[i].frameId}:${this.controllerId}:${this.logLevel}`];
+      const inputElement = Frame.document
+        .getElementById(options.elementIds[i].elementId);
+      if (inputElement) {
+        const {
+          state, tableName, validations, skyflowID,
+        } = inputElement.iFrameFormElement;
+        if (tableName) {
           if (
-            this.iFrameFormElements[formElements[i]].fieldType
-          === ELEMENTS.checkbox.name
+            inputElement.iFrameFormElement.fieldType
+        !== ELEMENTS.FILE_INPUT.name
           ) {
-            if (insertResponseObject[state.name]) {
-              insertResponseObject[state.name] = `${insertResponseObject[state.name]},${state.value
-              }`;
-            } else {
-              insertResponseObject[state.name] = state.value;
-            }
-          } else if (insertResponseObject[tableName] && !(skyflowID === '') && skyflowID === undefined) {
-            if (get(insertResponseObject[tableName], state.name)
+            if (
+              inputElement.iFrameFormElement.fieldType
+          === ELEMENTS.checkbox.name
+            ) {
+              if (insertResponseObject[state.name]) {
+                insertResponseObject[state.name] = `${insertResponseObject[state.name]},${state.value
+                }`;
+              } else {
+                insertResponseObject[state.name] = state.value;
+              }
+            } else if (insertResponseObject[tableName] && !(skyflowID === '') && skyflowID === undefined) {
+              if (get(insertResponseObject[tableName], state.name)
             && !(validations && checkForElementMatchRule(validations))) {
-              return Promise.reject(new SkyflowError(SKYFLOW_ERROR_CODE.DUPLICATE_ELEMENT,
-                [state.name, tableName], true));
-            }
-            set(
-              insertResponseObject[tableName],
-              state.name,
-              this.iFrameFormElements[formElements[i]].getUnformattedValue(),
-            );
-          } else if (skyflowID || skyflowID === '') {
-            if (skyflowID === '' || skyflowID === null) {
-              return Promise.reject(new SkyflowError(
-                SKYFLOW_ERROR_CODE.EMPTY_SKYFLOW_ID_IN_ADDITIONAL_FIELDS,
-                [],
-              ));
-            }
-            if (updateResponseObject[skyflowID]) {
+                return Promise.reject(new SkyflowError(SKYFLOW_ERROR_CODE.DUPLICATE_ELEMENT,
+                  [state.name, tableName], true));
+              }
               set(
-                updateResponseObject[skyflowID],
+                insertResponseObject[tableName],
                 state.name,
-                this.iFrameFormElements[formElements[i]].getUnformattedValue(),
+                inputElement.iFrameFormElement.getUnformattedValue(),
               );
+            } else if (skyflowID || skyflowID === '') {
+              if (skyflowID === '' || skyflowID === null) {
+                return Promise.reject(new SkyflowError(
+                  SKYFLOW_ERROR_CODE.EMPTY_SKYFLOW_ID_IN_ADDITIONAL_FIELDS,
+                ));
+              }
+              if (updateResponseObject[skyflowID]) {
+                set(
+                  updateResponseObject[skyflowID],
+                  state.name,
+                  inputElement.iFrameFormElement.getUnformattedValue(),
+                );
+              } else {
+                updateResponseObject[skyflowID] = {};
+                set(
+                  updateResponseObject[skyflowID],
+                  state.name,
+                  inputElement.iFrameFormElement.getUnformattedValue(),
+                );
+                set(
+                  updateResponseObject[skyflowID],
+                  'table',
+                  tableName,
+                );
+              }
             } else {
-              updateResponseObject[skyflowID] = {};
+              insertResponseObject[tableName] = {};
               set(
-                updateResponseObject[skyflowID],
+                insertResponseObject[tableName],
                 state.name,
-                this.iFrameFormElements[formElements[i]].getUnformattedValue(),
-              );
-              set(
-                updateResponseObject[skyflowID],
-                'table',
-                tableName,
+                inputElement.iFrameFormElement.getUnformattedValue(),
               );
             }
-          } else {
-            insertResponseObject[tableName] = {};
-            set(
-              insertResponseObject[tableName],
-              state.name,
-              this.iFrameFormElements[formElements[i]].getUnformattedValue(),
-            );
           }
         }
       }

--- a/src/core/internal/iframe-form/index.ts
+++ b/src/core/internal/iframe-form/index.ts
@@ -29,7 +29,6 @@ import {
 } from '../../../utils/validators';
 import {
   checkForElementMatchRule,
-  checkForValueMatch,
   constructElementsInsertReq,
   constructInsertRecordRequest,
   constructInsertRecordResponse,
@@ -1038,7 +1037,7 @@ export class IFrameForm {
     const updateResponseObject: any = {};
     let errorMessage = '';
     for (let i = 0; i < options.elementIds.length; i += 1) {
-      const Frame = window.parent.frames[`${options.elementIds[i].frameId}:${this.controllerId}:${this.logLevel}`];
+      const Frame = window.parent.frames[`${options.elementIds[i].frameId}:${this.controllerId}:${this.logLevel}:${btoa(this.clientDomain)}`];
       const inputElement = Frame.document
         .getElementById(options.elementIds[i].elementId);
       if (inputElement) {
@@ -1066,7 +1065,7 @@ export class IFrameForm {
     }
 
     for (let i = 0; i < options.elementIds.length; i += 1) {
-      const Frame = window.parent.frames[`${options.elementIds[i].frameId}:${this.controllerId}:${this.logLevel}`];
+      const Frame = window.parent.frames[`${options.elementIds[i].frameId}:${this.controllerId}:${this.logLevel}:${btoa(this.clientDomain)}`];
       const inputElement = Frame.document
         .getElementById(options.elementIds[i].elementId);
       if (inputElement) {

--- a/src/core/internal/iframe-form/index.ts
+++ b/src/core/internal/iframe-form/index.ts
@@ -1280,7 +1280,7 @@ export class IFrameForm {
 
       try {
         if (
-          frame.location.href === window.location.href
+          frame.location.href.split('?')[0] === window.location.href
           && frame.name === frameGlobalName
         ) {
           frameInstance = frame;

--- a/src/core/internal/index.ts
+++ b/src/core/internal/index.ts
@@ -113,7 +113,8 @@ export class FrameElement {
 
   private domLabel?: HTMLLabelElement;
 
-  private domInput?: HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement | HTMLFormElement;
+  private domInput?: (HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement | HTMLFormElement)
+  & { iFrameFormElement? : IFrameFormElement };
 
   public domError?: HTMLSpanElement;
 
@@ -170,7 +171,7 @@ export class FrameElement {
 
     this.domError = document.createElement('span');
 
-    let type;
+    let type:'select' | 'textarea' | 'input' = 'input';
     if (this.iFrameFormElement?.fieldType === ELEMENTS.dropdown.name) {
       type = 'select';
     } else if (this.iFrameFormElement?.fieldType === ELEMENTS.textarea.name) {
@@ -184,6 +185,7 @@ export class FrameElement {
 
     const inputElement = document.createElement(type);
     this.domInput = inputElement;
+    this.domInput.iFrameFormElement = this.iFrameFormElement;
     inputElement.setAttribute(CUSTOM_ROW_ID_ATTRIBUTE, this.htmlDivElement?.id?.split(':')[0] || '');
     this.inputParent.append(inputElement);
 

--- a/src/core/internal/reveal/reveal-frame.ts
+++ b/src/core/internal/reveal/reveal-frame.ts
@@ -69,10 +69,13 @@ class RevealFrame {
       .emit(
         ELEMENT_EVENTS_TO_IFRAME.REVEAL_FRAME_READY,
         { name: window.name },
-        (data: any) => {
-          RevealFrame.revealFrame = new RevealFrame(data.record, data.context);
-        },
+        () => {},
       );
+    const url = window.location?.href;
+    const configIndex = url.indexOf('?');
+    const encodedString = configIndex !== -1 ? decodeURIComponent(url.substring(configIndex + 1)) : '';
+    const parsedRecord = encodedString ? JSON.parse(atob(encodedString)) : {};
+    RevealFrame.revealFrame = new RevealFrame(parsedRecord.record, parsedRecord.context);
   }
 
   constructor(record, context) {

--- a/tests/core/external/collect/composable-container.test.js
+++ b/tests/core/external/collect/composable-container.test.js
@@ -26,13 +26,17 @@ jest.mock('../../../../src/libs/uuid', () => ({
 const mockUnmount = jest.fn();
 const updateMock = jest.fn();
 jest.mock('../../../../src/core/external/collect/collect-element');
-CollectElement.mockImplementation(()=>({
+CollectElement.mockImplementation((_,tempElements)=>{
+  tempElements.rows[0].elements.forEach((element)=>{
+    element.isMounted = true;
+  })
+  return {
   isMounted : ()=>(true),
   mount: jest.fn(),
   isValidElement: ()=>(true),
   unmount:mockUnmount,
   updateElement:updateMock
-}))
+}})
 
 jest.mock('../../../../src/event-emitter');
 const emitMock = jest.fn();
@@ -185,6 +189,10 @@ describe('test composable container class',()=>{
   });
 
   it('test collect',()=>{
+    let readyCb;
+    on.mockImplementation((name,cb)=>{
+      readyCb = cb;
+    })
     const div = document.createElement('div');
     div.id = 'composable'
     document.body.append(div);
@@ -192,9 +200,13 @@ describe('test composable container class',()=>{
     const element1 = container.create(cvvElement);
     const element2 = container.create(cardNumberElement);
     emitterSpy();
+    readyCb({name:`${COLLECT_FRAME_CONTROLLER}1234`},jest.fn());
+    
     container.mount('#composable');
    
     container.collect();
+
+    on.mockImplementation((name,cb)=>{emitterSpy = cb})
   });
 
   it('test collect without mounting the container',(done)=>{

--- a/tests/core/internal/frame-controller.test.js
+++ b/tests/core/internal/frame-controller.test.js
@@ -35,6 +35,8 @@ const on = jest.fn();
 
 const tableCol = btoa('table.col');
 const collect_element = `element:CVV:${tableCol}`;
+const collect_element_textarea = `element:${ELEMENTS.textarea.name}:${tableCol}`;
+const collect_element_dropdown = `element:${ELEMENTS.dropdown.name}:${tableCol}`;
 
 const context = {
   logLevel: LogLevel.ERROR,
@@ -295,6 +297,131 @@ describe('test frame controller', () => {
 
     expect(div.getElementsByTagName('select').length).toBe(0);
     expect(div.getElementsByTagName('img').length).toBe(1); // only cardicon
+
+    element.setupInputField();
+  });
+
+  test('FrameElement constructor : textarea', () => {
+    const div = document.createElement('div');
+
+    const formElement = new IFrameFormElement(collect_element_textarea, {}, context);
+    const element = new FrameElement(formElement, {
+      label: 'label',
+      inputStyles,
+      labelStyles,
+      errorTextStyles,
+    }, div);
+
+    const inst = EventEmitter.mock.instances[0];
+    const onSpy = inst.on.mock.calls;
+
+    const focusCb = onSpy
+      .filter((data) => data[0] === ELEMENT_EVENTS_TO_CLIENT.FOCUS);
+
+    focusCb[0][1](state);
+
+    const blurCb = onSpy
+      .filter((data) => data[0] === ELEMENT_EVENTS_TO_CLIENT.BLUR);
+
+
+    blurCb[0][1](state);
+
+    blurCb[0][1]({
+      ...state,
+      isValid: false,
+      isEmpty: false,
+    });
+
+    const changeCb = onSpy
+      .filter((data) => data[0] === ELEMENT_EVENTS_TO_CLIENT.CHANGE);
+
+    changeCb[0][1](state);
+
+    const setCb = onSpy
+      .filter((data) => data[0] === ELEMENT_EVENTS_TO_IFRAME.SET_VALUE);
+    setCb[0][1]({
+      options: {
+        label: 'updatedLabel',
+        inputStyles,
+        labelStyles,
+        errorTextStyles,
+        table:'updatedTable',
+        column:'updateColumn',
+        placeholder:'XX',
+        validations:[
+          {
+            type:ValidationRuleType.LENGTH_MATCH_RULE,
+            params:{
+              min:2,
+            }
+          }
+        ],
+        skyflowID: 'updated-skyflow-id',
+      },
+    });
+
+    element.setupInputField();
+  });
+
+  test('FrameElement constructor : dropdown', () => {
+    const div = document.createElement('div');
+
+    const formElement = new IFrameFormElement(collect_element_dropdown, {}, context);
+    const element = new FrameElement(formElement, {
+      label: 'label',
+      inputStyles,
+      labelStyles,
+      errorTextStyles,
+      options:["dummyOptions"]
+    }, div);
+
+    const inst = EventEmitter.mock.instances[0];
+    const onSpy = inst.on.mock.calls;
+
+    const focusCb = onSpy
+      .filter((data) => data[0] === ELEMENT_EVENTS_TO_CLIENT.FOCUS);
+
+    focusCb[0][1](state);
+
+    const blurCb = onSpy
+      .filter((data) => data[0] === ELEMENT_EVENTS_TO_CLIENT.BLUR);
+
+
+    blurCb[0][1](state);
+
+    blurCb[0][1]({
+      ...state,
+      isValid: false,
+      isEmpty: false,
+    });
+
+    const changeCb = onSpy
+      .filter((data) => data[0] === ELEMENT_EVENTS_TO_CLIENT.CHANGE);
+
+    changeCb[0][1](state);
+
+    const setCb = onSpy
+      .filter((data) => data[0] === ELEMENT_EVENTS_TO_IFRAME.SET_VALUE);
+    setCb[0][1]({
+      options: {
+        label: 'updatedLabel',
+        inputStyles,
+        labelStyles,
+        errorTextStyles,
+        table:'updatedTable',
+        column:'updateColumn',
+        placeholder:'XX',
+        validations:[
+          {
+            type:ValidationRuleType.LENGTH_MATCH_RULE,
+            params:{
+              min:2,
+            }
+          }
+        ],
+        skyflowID: 'updated-skyflow-id',
+      },
+    });
 
     element.setupInputField();
   });

--- a/tests/core/internal/frame-elements.test.js
+++ b/tests/core/internal/frame-elements.test.js
@@ -79,14 +79,51 @@ describe('test frame elements', () => {
         windowSpy.mockImplementation(() => ({
             name: `${FRAME_ELEMENT}:CARD_NUMBER:${btoa('123')}:ERROR`,
             location: {
-              href: `http://localhost/?${btoa(JSON.stringify(element))}`,
+              href: `http://localhost/?${btoa(JSON.stringify({record:element}))}`,
             }
         }));
 
         emitSpy = jest.spyOn(bus, 'emit');
     })
+    test('FrameElements constructor : empty path', () => {
+      windowSpy.mockImplementation(() => ({
+        name: `${FRAME_ELEMENT}:CARD_NUMBER:${btoa('123')}:ERROR`,
+        location: {
+          href: `http://localhost`,
+        }
+    }))
+      const onSpy = jest.spyOn(bus, 'on');
+
+        FrameElements.start()
+        const emitEventName = emitSpy.mock.calls[0][0];
+        const emitCb = emitSpy.mock.calls[0][2];
+        expect(emitEventName.includes(ELEMENT_EVENTS_TO_IFRAME.FRAME_READY)).toBeTruthy()
+        emitCb(element);
+        const mockCreateElement = jest.fn().mockImplementation(()=>{
+            return {
+                resetEvents: jest.fn(),
+                on: jest.fn(),
+                getStatus: jest.fn(()=>({
+                    isFocused: false,
+                    isValid: false,
+                    isEmpty: true,
+                    isComplete: false,
+                })),
+                fieldType: 'CARD_NUMBER',
+                state:{name:''},
+                setValidation:jest.fn(),
+                setReplacePattern: jest.fn(),
+                setMask:jest.fn(),
+                getValue: jest.fn(),
+                setValue: jest.fn(),
+            }
+        })
+        const frameElement = new FrameElements(mockCreateElement, {}, 'ERROR')
+    })
     test('FrameElements constructor', () => {
       const onSpy = jest.spyOn(bus, 'on');
+
+        FrameElements.init(jest.fn().mockReturnValue({resetEvents:jest.fn(),on:jest.fn(),fieldType:'group',getStatus:jest.fn().mockReturnValue({}),state:{}}),{})
 
         FrameElements.start()
 
@@ -115,12 +152,6 @@ describe('test frame elements', () => {
             }
         })
         const frameElement = new FrameElements(mockCreateElement, {}, 'ERROR')
-        const heigtEvent = onSpy.mock.calls[0][1];
-        const cb = jest.fn();
-        heigtEvent({},cb);
-        cb();
-
-
     })
 
 })
@@ -133,31 +164,31 @@ describe('test composable frame elements', () => {
       windowSpy.mockImplementation(() => ({
           name: `${FRAME_ELEMENT}:group:${btoa('123')}:ERROR`,
           location: {
-            href: `http://localhost/?${btoa(JSON.stringify(element))}`,
+            href: `http://localhost/?${btoa(JSON.stringify({record:element}))}`,
           }
       }));
 
       emitSpy = jest.spyOn(bus, 'emit');
   });
 
-  test('FrameElements constructor', () => {
-      FrameElements.start()
+  test('FrameElements constructor : empty path', () => {
+    windowSpy.mockImplementation(() => ({
+      name: `${FRAME_ELEMENT}:CARD_NUMBER:${btoa('123')}:ERROR`,
+      location: {
+        href: `http://localhost`,
+      }
+  }))
+    const onSpy = jest.spyOn(bus, 'on');
 
+      FrameElements.start()
       const emitEventName = emitSpy.mock.calls[0][0];
       const emitCb = emitSpy.mock.calls[0][2];
       expect(emitEventName.includes(ELEMENT_EVENTS_TO_IFRAME.FRAME_READY)).toBeTruthy()
       emitCb(element);
-
       const mockCreateElement = jest.fn().mockImplementation(()=>{
           return {
               resetEvents: jest.fn(),
-              on: jest.fn().mockImplementation((name,cb)=>{
-                if(name === 'BLUR'){
-                  cb({
-                    error:'state'
-                  })
-                }
-              }),
+              on: jest.fn(),
               getStatus: jest.fn(()=>({
                   isFocused: false,
                   isValid: false,
@@ -171,11 +202,12 @@ describe('test composable frame elements', () => {
               setMask:jest.fn(),
               getValue: jest.fn(),
               setValue: jest.fn(),
-
           }
       })
       const frameElement = new FrameElements(mockCreateElement, {}, 'ERROR')
-  });
+  })
+
+  
 
     
   test('FrameElements init', () => {

--- a/tests/core/internal/frame-elements.test.js
+++ b/tests/core/internal/frame-elements.test.js
@@ -77,7 +77,7 @@ describe('test frame elements', () => {
     beforeEach(() => {
         windowSpy = jest.spyOn(global, 'window', 'get');
         windowSpy.mockImplementation(() => ({
-            name: `${FRAME_ELEMENT}:CARD_NUMBER:${btoa('123')}:ERROR`,
+            name: `${FRAME_ELEMENT}:CARD_NUMBER:${btoa('123')}:ERROR:`,
             location: {
               href: `http://localhost/?${btoa(JSON.stringify({record:element}))}`,
             }
@@ -87,7 +87,7 @@ describe('test frame elements', () => {
     })
     test('FrameElements constructor : empty path', () => {
       windowSpy.mockImplementation(() => ({
-        name: `${FRAME_ELEMENT}:CARD_NUMBER:${btoa('123')}:ERROR`,
+        name: `${FRAME_ELEMENT}:CARD_NUMBER:${btoa('1234')}:ERROR:`,
         location: {
           href: `http://localhost`,
         }
@@ -162,7 +162,7 @@ describe('test composable frame elements', () => {
   beforeEach(() => {
       windowSpy = jest.spyOn(global, 'window', 'get');
       windowSpy.mockImplementation(() => ({
-          name: `${FRAME_ELEMENT}:group:${btoa('123')}:ERROR`,
+          name: `${FRAME_ELEMENT}:group:${btoa('123')}:ERROR:`,
           location: {
             href: `http://localhost/?${btoa(JSON.stringify({record:element}))}`,
           }
@@ -171,16 +171,19 @@ describe('test composable frame elements', () => {
       emitSpy = jest.spyOn(bus, 'emit');
   });
 
-  test('FrameElements constructor : empty path', () => {
+  test('FrameElements constructor with composable elements : empty path', () => {
     windowSpy.mockImplementation(() => ({
-      name: `${FRAME_ELEMENT}:CARD_NUMBER:${btoa('123')}:ERROR`,
+      name: `${FRAME_ELEMENT}:CARD_NUMBER:${btoa('123')}:ERROR:`,
       location: {
         href: `http://localhost`,
       }
-  }))
-    const onSpy = jest.spyOn(bus, 'on');
+    }))
+      const onSpy = jest.spyOn(bus, 'on');
+      FrameElements.group = [];
+      // FrameElements.setup();
 
       FrameElements.start()
+      
       const emitEventName = emitSpy.mock.calls[0][0];
       const emitCb = emitSpy.mock.calls[0][2];
       expect(emitEventName.includes(ELEMENT_EVENTS_TO_IFRAME.FRAME_READY)).toBeTruthy()
@@ -206,8 +209,6 @@ describe('test composable frame elements', () => {
       })
       const frameElement = new FrameElements(mockCreateElement, {}, 'ERROR')
   })
-
-  
 
     
   test('FrameElements init', () => {

--- a/tests/core/internal/frame-elements.test.js
+++ b/tests/core/internal/frame-elements.test.js
@@ -78,6 +78,9 @@ describe('test frame elements', () => {
         windowSpy = jest.spyOn(global, 'window', 'get');
         windowSpy.mockImplementation(() => ({
             name: `${FRAME_ELEMENT}:CARD_NUMBER:${btoa('123')}:ERROR`,
+            location: {
+              href: `http://localhost/?${btoa(JSON.stringify(element))}`,
+            }
         }));
 
         emitSpy = jest.spyOn(bus, 'emit');
@@ -129,6 +132,9 @@ describe('test composable frame elements', () => {
       windowSpy = jest.spyOn(global, 'window', 'get');
       windowSpy.mockImplementation(() => ({
           name: `${FRAME_ELEMENT}:group:${btoa('123')}:ERROR`,
+          location: {
+            href: `http://localhost/?${btoa(JSON.stringify(element))}`,
+          }
       }));
 
       emitSpy = jest.spyOn(bus, 'emit');

--- a/tests/core/internal/iframe-form/iframe-form.test.js
+++ b/tests/core/internal/iframe-form/iframe-form.test.js
@@ -14,6 +14,7 @@ import { parameterizedString } from '../../../../src/utils/logs-helper';
 
 const tableCol = btoa('1234')
 const collect_element = `element:CVV:${tableCol}`;
+const checkbox_element = `element:${ELEMENTS.checkbox.name}:${tableCol}`
 const test_collect_element = `element:CARD_NUMBER:${tableCol}`;
 const file_element = `element:FILE_INPUT:${tableCol}`;
 
@@ -172,11 +173,22 @@ describe('test iframeFormelement', () => {
     })
     test('test tokenize error case', () => {
         const element = new IFrameFormElement(`element:EXPIRATION_MONTH:${tableCol}`, {}, context)
-        const form = new IFrameForm(element)
+        const form = new IFrameForm("controllerId","",'ERROR')
+        jest.spyOn(window,'parent','get').mockImplementation(()=>({
+            frames:{
+                [`element:EXPIRATION_MONTH:${tableCol}:controllerId:ERROR`]:{
+                    document:{
+                        getElementById:()=>({
+                            iFrameFormElement:element
+                        })
+                    }
+                }
+            }
+        }))
         form.setClient(clientObj1)
         form.setClientMetadata(metaData)
         form.setContext(context)
-        expect(form.tokenize()).rejects.toThrow(SkyflowError)
+        expect(form.tokenize({elementIds:[{elemenId:`element:EXPIRATION_MONTH:${tableCol}`,frameId:`element:EXPIRATION_MONTH:${tableCol}`}]})).rejects.toThrow(SkyflowError)
     })
 
     test('test setValue for expiration_date', () => {
@@ -619,6 +631,95 @@ describe('test iframeForm collect method', () => {
         });
     });
 
+    test('initialize iframeform and submit collect with invalid input : client has error', (done) => {
+        const form = new IFrameForm("controllerId", "", "ERROR");
+        form.setClient(clientObj)
+        form.setClientMetadata(metaData)
+        form.setContext(context)
+
+        const frameReadyEvent = on.mock.calls.filter((data) => data[0] === ELEMENT_EVENTS_TO_IFRAME.FRAME_READY + 'controllerId');
+        const frameReadyCb = frameReadyEvent[0][1];
+        expect(() => { frameReadyCb({}) }).toThrow(SkyflowError)
+
+        frameReadyCb({ name: COLLECT_FRAME_CONTROLLER })
+
+        expect(() => { frameReadyCb({ name: "element:type:aW52YWxpZA==" }) }).toThrow(SkyflowError)
+        const skyflowInit = jest.fn();
+        let windowSpy = jest.spyOn(global, 'window', 'get');
+        windowSpy.mockImplementation(() => ({
+            parent: {
+                frames: [{
+                    name: collect_element,
+                    location: {
+                        href: 'http://iframe.html'
+                    },
+                    Skyflow: {
+                        init: skyflowInit
+                    }
+                }]
+            },
+            location: {
+                href: 'http://iframe.html'
+            }
+        }));
+
+        frameReadyCb({ name:collect_element})
+
+        const createFormElement = skyflowInit.mock.calls[0][0]
+        const element = createFormElement(collect_element,undefined,undefined,true)
+
+        const setErrorEvent = on.mock.calls.filter((data)=>data[0]===ELEMENT_EVENTS_TO_IFRAME.COLLECT_ELEMENT_SET_ERROR)
+        console.log("setErrorEvent",setErrorEvent)
+        const setErrorCb = setErrorEvent[0][1]
+
+        setErrorCb({isTriggerError:true,clientErrorText:"Error",name:collect_element})
+
+        const tokenizationEvent = on.mock.calls.filter((data) => data[0] === ELEMENT_EVENTS_TO_IFRAME.TOKENIZATION_REQUEST + 'controllerId');
+        const tokenizationCb = tokenizationEvent[0][1];
+        const cb2 = jest.fn();
+
+        windowSpy.mockImplementation(() => ({
+            parent: {
+                frames: {
+                    [`${collect_element}:controllerId:ERROR`]:{
+                        document:{
+                            getElementById:()=>({
+                                iFrameFormElement:element
+                            })
+                        }
+                    }
+                }
+            },
+            location: {
+                href: 'http://iframe.html'
+            }
+        }));
+        tokenizationCb({...data,elementIds:[{elementId:collect_element,frameId:collect_element}]}, cb2)
+
+        setTimeout(() => {
+            expect(cb2.mock.calls[0][0].error.message).toBeDefined()
+            done()
+        }, 1000)
+
+
+        windowSpy.mockImplementation(() => ({
+            parent: {
+                frames: [{
+                    name: collect_element,
+                    location: {
+                        href: 'http://iframe.html'
+                    },
+                    Skyflow: {
+                        init: skyflowInit
+                    }
+                }]
+            },
+            location: {
+                href: 'http://iframe.html'
+            }
+        }));
+    })
+
     test('initialize iframeform and submit collect with invalid input', (done) => {
         const form = new IFrameForm("controllerId", "", "ERROR");
         form.setClient(clientObj)
@@ -660,7 +761,23 @@ describe('test iframeForm collect method', () => {
         const tokenizationEvent = on.mock.calls.filter((data) => data[0] === ELEMENT_EVENTS_TO_IFRAME.TOKENIZATION_REQUEST + 'controllerId');
         const tokenizationCb = tokenizationEvent[0][1];
         const cb2 = jest.fn();
-        tokenizationCb(data, cb2)
+        windowSpy.mockImplementation(() => ({
+            parent: {
+                frames: {
+                    [`${collect_element}:controllerId:ERROR`]:{
+                        document:{
+                            getElementById:()=>({
+                                iFrameFormElement:element
+                            })
+                        }
+                    }
+                }
+            },
+            location: {
+                href: 'http://iframe.html'
+            }
+        }));
+        tokenizationCb({...data,elementIds:[{elementId:collect_element,frameId:collect_element}]}, cb2)
 
         setTimeout(() => {
             expect(cb2.mock.calls[0][0].error.message).toBeDefined()
@@ -668,7 +785,7 @@ describe('test iframeForm collect method', () => {
 
         element.setValue('123')
         const cb3 = jest.fn()
-        tokenizationCb(data, cb3)
+        tokenizationCb({...data,elementIds:[{elementId:collect_element,frameId:collect_element}]}, cb3)
 
         setTimeout(() => {
             expect(cb3.mock.calls[0][0].records.length).toBe(2);
@@ -689,13 +806,144 @@ describe('test iframeForm collect method', () => {
                         col: '123'
                     }
                 }]
-            }
+            },
+            elementIds:[{elementId:collect_element,frameId:collect_element}]
         }, cb4)
 
         setTimeout(() => {
             expect(cb4.mock.calls[0][0].error).toBeDefined()
             done()
         }, 1000)
+
+        windowSpy.mockImplementation(() => ({
+            parent: {
+                frames: [{
+                    name: collect_element,
+                    location: {
+                        href: 'http://iframe.html'
+                    },
+                    Skyflow: {
+                        init: skyflowInit
+                    }
+                }]
+            },
+            location: {
+                href: 'http://iframe.html'
+            }
+        }));
+    })
+
+    test('initialize iframeform and submit collect with invalid input and not required field', (done) => {
+        const form = new IFrameForm("controllerId", "", "ERROR");
+        form.setClient(clientObj)
+        form.setClientMetadata(metaData)
+        form.setContext(context)
+
+        const frameReadyEvent = on.mock.calls.filter((data) => data[0] === ELEMENT_EVENTS_TO_IFRAME.FRAME_READY + 'controllerId');
+        const frameReadyCb = frameReadyEvent[0][1];
+
+        expect(() => { frameReadyCb({}) }).toThrow(SkyflowError)
+
+        frameReadyCb({ name: COLLECT_FRAME_CONTROLLER })
+
+        expect(() => { frameReadyCb({ name: "element:type:aW52YWxpZA==" }) }).toThrow(SkyflowError)
+        const skyflowInit = jest.fn();
+        let windowSpy = jest.spyOn(global, 'window', 'get');
+        windowSpy.mockImplementation(() => ({
+            parent: {
+                frames: [{
+                    name: collect_element,
+                    location: {
+                        href: 'http://iframe.html'
+                    },
+                    Skyflow: {
+                        init: skyflowInit
+                    }
+                }]
+            },
+            location: {
+                href: 'http://iframe.html'
+            }
+        }));
+
+        frameReadyCb({ name:collect_element})
+
+        const createFormElement = skyflowInit.mock.calls[0][0]
+        const element = createFormElement(collect_element)
+
+        const tokenizationEvent = on.mock.calls.filter((data) => data[0] === ELEMENT_EVENTS_TO_IFRAME.TOKENIZATION_REQUEST + 'controllerId');
+        const tokenizationCb = tokenizationEvent[0][1];
+        const cb2 = jest.fn();
+        windowSpy.mockImplementation(() => ({
+            parent: {
+                frames: {
+                    [`${collect_element}:controllerId:ERROR`]:{
+                        document:{
+                            getElementById:()=>({
+                                iFrameFormElement:element
+                            })
+                        }
+                    }
+                }
+            },
+            location: {
+                href: 'http://iframe.html'
+            }
+        }));
+        tokenizationCb({...data,elementIds:[{elementId:collect_element,frameId:collect_element}]}, cb2)
+
+        setTimeout(() => {
+            expect(cb2.mock.calls[0][0].error.message).toBeDefined()
+        }, 1000)
+
+        element.setValue('123')
+        const cb3 = jest.fn()
+        tokenizationCb({...data,elementIds:[{elementId:collect_element,frameId:collect_element}]}, cb3)
+
+        setTimeout(() => {
+            expect(cb3.mock.calls[0][0].records.length).toBe(2);
+        }, 1000)
+
+        element.fieldName = 'col';
+        element.tableName = 'table';
+        element.state.name = 'col';
+
+        const cb4 = jest.fn()
+        tokenizationCb({
+            ...data,
+            additionalFields: {
+                ...data.additionalFields,
+                records: [{
+                    table: 'table',
+                    fields: {
+                        col: '123'
+                    }
+                }]
+            },
+            elementIds:[{elementId:collect_element,frameId:collect_element}]
+        }, cb4)
+
+        setTimeout(() => {
+            expect(cb4.mock.calls[0][0].error).toBeDefined()
+            done()
+        }, 1000)
+
+        windowSpy.mockImplementation(() => ({
+            parent: {
+                frames: [{
+                    name: collect_element,
+                    location: {
+                        href: 'http://iframe.html'
+                    },
+                    Skyflow: {
+                        init: skyflowInit
+                    }
+                }]
+            },
+            location: {
+                href: 'http://iframe.html'
+            }
+        }));
 
     })
 
@@ -900,7 +1148,23 @@ describe('test iframeForm collect method', () => {
         const tokenizationEvent = on.mock.calls.filter((data) => data[0] === ELEMENT_EVENTS_TO_IFRAME.TOKENIZATION_REQUEST + 'controllerId');
         const tokenizationCb = tokenizationEvent[0][1];
         const cb2 = jest.fn();
-        tokenizationCb(data, cb2)
+        windowSpy.mockImplementation(() => ({
+            parent: {
+                frames: {
+                    [`${collect_element}:controllerId:ERROR`]:{
+                        document:{
+                            getElementById:()=>({
+                                iFrameFormElement:element
+                            })
+                        }
+                    }
+                }
+            },
+            location: {
+                href: 'http://iframe.html'
+            }
+        }));
+        tokenizationCb({...data,elementIds:[{elementId:collect_element,frameId:collect_element}]}, cb2)
 
         setTimeout(() => {
             expect(cb2.mock.calls[0][0].error.message).toBeDefined()
@@ -908,7 +1172,7 @@ describe('test iframeForm collect method', () => {
 
         element.setValue('123')
         const cb3 = jest.fn()
-        tokenizationCb(data, cb3)
+        tokenizationCb({...data,elementIds:[{elementId:collect_element,frameId:collect_element}]}, cb3)
 
         setTimeout(() => {
             expect(cb3.mock.calls[0][0].records.length).toBe(2);
@@ -929,7 +1193,8 @@ describe('test iframeForm collect method', () => {
                         col: '123'
                     }
                 }]
-            }
+            },
+            elementIds:[{elementId:collect_element,frameId:collect_element}]
         }, cb4)
 
         setTimeout(() => {
@@ -937,7 +1202,22 @@ describe('test iframeForm collect method', () => {
             done()
         }, 1000)
 
-
+        windowSpy.mockImplementation(() => ({
+            parent: {
+                frames: [{
+                    name: collect_element,
+                    location: {
+                        href: 'http://iframe.html'
+                    },
+                    Skyflow: {
+                        init: skyflowInit
+                    }
+                }]
+            },
+            location: {
+                href: 'http://iframe.html'
+            }
+        }));
     })
 
     test('collect submit without client initializatiob', () => {
@@ -962,26 +1242,97 @@ describe('test iframeForm collect method', () => {
     })
     test('collect error second case', () => {
         const form = new IFrameForm("controllerId", "", "ERROR");
+        const element =  new IFrameFormElement(collect_element,"",{},context)
+        element.setValue("123")
+        let windowSpy = jest.spyOn(global, 'window', 'get');
+        const skyflowInit = jest.fn();
+        windowSpy.mockImplementation(() => ({
+            parent: {
+                frames: {
+                    [`${collect_element}:controllerId:ERROR`]:{
+                        document:{
+                            getElementById:()=>({
+                                iFrameFormElement:element
+                            })
+                        }
+                    }
+                }
+            },
+            location: {
+                href: 'http://iframe.html'
+            }
+        }));
         form.setContext(context)
         form.setClient(clientObj1)
-        expect(form.tokenize(records)).rejects.toMatchObject({"error": {"code": 404, "description": "Not Found"}});
+        expect(form.tokenize({...records,elementIds:[{elementId:collect_element,frameId:collect_element}]})).rejects.toMatchObject({"error": {"code": 404, "description": "Not Found"}});
+        windowSpy.mockImplementation(() => ({
+            parent: {
+                frames: [{
+                    name: collect_element,
+                    location: {
+                        href: 'http://iframe.html'
+                    },
+                    Skyflow: {
+                        init: skyflowInit
+                    }
+                }]
+            },
+            location: {
+                href: 'http://iframe.html'
+            }
+        }));
     })
     test('insert records with tokens as true', (done) => {
         const form = new IFrameForm("controllerId", "", "ERROR");
+        const element =  new IFrameFormElement(collect_element,"",{},context)
         form.setClient(clientObj)
         form.setClientMetadata(metaData)
         form.setContext(context)
-
+        element.setValue("123")
+        const skyflowInit = jest.fn();
+        let windowSpy = jest.spyOn(global, 'window', 'get');
+        windowSpy.mockImplementation(() => ({
+            parent: {
+                frames: {
+                    [`${collect_element}:controllerId:ERROR`]:{
+                        document:{
+                            getElementById:()=>({
+                                iFrameFormElement:element
+                            })
+                        }
+                    }
+                }
+            },
+            location: {
+                href: 'http://iframe.html'
+            }
+        }));
         const tokenizationEvent = on.mock.calls.filter((data) => data[0] === ELEMENT_EVENTS_TO_IFRAME.TOKENIZATION_REQUEST + 'controllerId');
         const tokenizationCb = tokenizationEvent[0][1];
         const cb2 = jest.fn();
-        tokenizationCb(data, cb2);
+        tokenizationCb({...data,elementIds:[{elementId:collect_element,frameId:collect_element}]}, cb2);
         setTimeout(() => {
             expect(cb2.mock.calls[0][0].records.length).toBe(2);
             expect(cb2.mock.calls[0][0].records[0].table).toBe('table');
             expect(Object.keys(cb2.mock.calls[0][0].records[0].fields).length).toBe(2);
             done()
         }, 1000)
+        windowSpy.mockImplementation(() => ({
+            parent: {
+                frames: [{
+                    name: collect_element,
+                    location: {
+                        href: 'http://iframe.html'
+                    },
+                    Skyflow: {
+                        init: skyflowInit
+                    }
+                }]
+            },
+            location: {
+                href: 'http://iframe.html'
+            }
+        }));
     })
     let clientObj1 = {
         config: {},
@@ -995,6 +1346,140 @@ describe('test iframeForm collect method', () => {
     }
     test('ererr', (done) => {
         const form = new IFrameForm("controllerId", "", "ERROR");
+        const element =  new IFrameFormElement(collect_element,"",{},context)
+        form.setClient(clientObj1)
+        form.setClientMetadata(metaData)
+        form.setContext(context)
+
+        element.setValue("123")
+        const skyflowInit = jest.fn();
+        let windowSpy = jest.spyOn(global, 'window', 'get');
+        windowSpy.mockImplementation(() => ({
+            parent: {
+                frames: {
+                    [`${collect_element}:controllerId:ERROR`]:{
+                        document:{
+                            getElementById:()=>({
+                                iFrameFormElement:element
+                            })
+                        }
+                    }
+                }
+            },
+            location: {
+                href: 'http://iframe.html'
+            }
+        }));
+
+        const tokenizationEvent = on.mock.calls.filter((data) => data[0] === ELEMENT_EVENTS_TO_IFRAME.TOKENIZATION_REQUEST + 'controllerId');
+        const tokenizationCb = tokenizationEvent[0][1];
+        const cb2 = jest.fn();
+        tokenizationCb({...data,elementIds:[{elementId:collect_element,frameId:collect_element}]}, cb2);
+        setTimeout(() => {
+            expect(cb2.mock.calls[0][0].error).toBeDefined();
+            done()
+        }, 1000)
+        form.tokenize({...data,elementIds:[{elementId:collect_element,frameId:collect_element}]}).then().catch( err => {
+            expect(err).toBeDefined();
+        })
+        windowSpy.mockImplementation(() => ({
+            parent: {
+                frames: [{
+                    name: collect_element,
+                    location: {
+                        href: 'http://iframe.html'
+                    },
+                    Skyflow: {
+                        init: skyflowInit
+                    }
+                }]
+            },
+            location: {
+                href: 'http://iframe.html'
+            }
+        }));
+    })
+
+    test('inputElementNotFound', (done) => {
+        const form = new IFrameForm("controllerId", "", "ERROR");
+        const element =  new IFrameFormElement(collect_element,"",{},context)
+        form.setClient(clientObj1)
+        form.setClientMetadata(metaData)
+        form.setContext(context)
+
+        element.setValue("123")
+        const skyflowInit = jest.fn();
+        let windowSpy = jest.spyOn(global, 'window', 'get');
+        windowSpy.mockImplementation(() => ({
+            parent: {
+                frames: {
+                    [`${collect_element}:controllerId:ERROR`]:{
+                        document:{
+                            getElementById:()=>(undefined)
+                        }
+                    }
+                }
+            },
+            location: {
+                href: 'http://iframe.html'
+            }
+        }));
+
+        const tokenizationEvent = on.mock.calls.filter((data) => data[0] === ELEMENT_EVENTS_TO_IFRAME.TOKENIZATION_REQUEST + 'controllerId');
+        const tokenizationCb = tokenizationEvent[0][1];
+        const cb2 = jest.fn();
+        tokenizationCb({...data,elementIds:[{elementId:collect_element,frameId:collect_element}]}, cb2);
+        setTimeout(() => {
+            expect(cb2.mock.calls[0][0].error).toBeDefined();
+            done()
+        }, 1000)
+        form.tokenize({...data,elementIds:[{elementId:collect_element,frameId:collect_element}]}).then().catch( err => {
+            expect(err).toBeDefined();
+        })
+        windowSpy.mockImplementation(() => ({
+            parent: {
+                frames: [{
+                    name: collect_element,
+                    location: {
+                        href: 'http://iframe.html'
+                    },
+                    Skyflow: {
+                        init: skyflowInit
+                    }
+                }]
+            },
+            location: {
+                href: 'http://iframe.html'
+            }
+        }));
+    })
+
+    test('success with skyflowID', (done) => {
+        const form = new IFrameForm("controllerId", "", "ERROR");
+        const element =  new IFrameFormElement(collect_element,"",{},context)
+
+        element.setValue("123")
+        element.skyflowID = "testID"
+        element.tableName = "table"
+        const skyflowInit = jest.fn();
+        let windowSpy = jest.spyOn(global, 'window', 'get');
+        windowSpy.mockImplementation(() => ({
+            parent: {
+                frames: {
+                    [`${collect_element}:controllerId:ERROR`]:{
+                        document:{
+                            getElementById:()=>({
+                                iFrameFormElement:element
+                            })
+                        }
+                    }
+                }
+            },
+            location: {
+                href: 'http://iframe.html'
+            }
+        }));
+
         form.setClient(clientObj1)
         form.setClientMetadata(metaData)
         form.setContext(context)
@@ -1002,17 +1487,56 @@ describe('test iframeForm collect method', () => {
         const tokenizationEvent = on.mock.calls.filter((data) => data[0] === ELEMENT_EVENTS_TO_IFRAME.TOKENIZATION_REQUEST + 'controllerId');
         const tokenizationCb = tokenizationEvent[0][1];
         const cb2 = jest.fn();
-        tokenizationCb(data, cb2);
+        tokenizationCb({...data,elementIds:[{elementId:collect_element,frameId:collect_element}]}, cb2);
         setTimeout(() => {
             expect(cb2.mock.calls[0][0].error).toBeDefined();
             done()
         }, 1000)
-        form.tokenize(data).then().catch( err => {
+        form.tokenize({...data,elementIds:[{elementId:collect_element,frameId:collect_element}]}).then().catch( err => {
             expect(err).toBeDefined();
         })
+        windowSpy.mockImplementation(() => ({
+            parent: {
+                frames: [{
+                    name: collect_element,
+                    location: {
+                        href: 'http://iframe.html'
+                    },
+                    Skyflow: {
+                        init: skyflowInit
+                    }
+                }]
+            },
+            location: {
+                href: 'http://iframe.html'
+            }
+        }));
     })
+
     test('success', (done) => {
         const form = new IFrameForm("controllerId", "", "ERROR");
+        const element =  new IFrameFormElement(collect_element,"",{},context)
+
+        element.setValue("123")
+        const skyflowInit = jest.fn();
+        let windowSpy = jest.spyOn(global, 'window', 'get');
+        windowSpy.mockImplementation(() => ({
+            parent: {
+                frames: {
+                    [`${collect_element}:controllerId:ERROR`]:{
+                        document:{
+                            getElementById:()=>({
+                                iFrameFormElement:element
+                            })
+                        }
+                    }
+                }
+            },
+            location: {
+                href: 'http://iframe.html'
+            }
+        }));
+
         form.setClient(clientObj1)
         form.setClientMetadata(metaData)
         form.setContext(context)
@@ -1020,21 +1544,119 @@ describe('test iframeForm collect method', () => {
         const tokenizationEvent = on.mock.calls.filter((data) => data[0] === ELEMENT_EVENTS_TO_IFRAME.TOKENIZATION_REQUEST + 'controllerId');
         const tokenizationCb = tokenizationEvent[0][1];
         const cb2 = jest.fn();
-        tokenizationCb(data, cb2);
+        tokenizationCb({...data,elementIds:[{elementId:collect_element,frameId:collect_element}]}, cb2);
         setTimeout(() => {
             expect(cb2.mock.calls[0][0].error).toBeDefined();
             done()
         }, 1000)
-        form.tokenize(data).then().catch( err => {
+        form.tokenize({...data,elementIds:[{elementId:collect_element,frameId:collect_element}]}).then().catch( err => {
             expect(err).toBeDefined();
         })
+        windowSpy.mockImplementation(() => ({
+            parent: {
+                frames: [{
+                    name: collect_element,
+                    location: {
+                        href: 'http://iframe.html'
+                    },
+                    Skyflow: {
+                        init: skyflowInit
+                    }
+                }]
+            },
+            location: {
+                href: 'http://iframe.html'
+            }
+        }));
     })
-    test('insert records duplicate error', (done) => {
+
+    test('success : checkbox', (done) => {
+        const form = new IFrameForm("controllerId", "", "ERROR");
+        const element =  new IFrameFormElement(checkbox_element,"",{},context)
+        element.tableName = "tableName"
+        element.setValue(true)
+        const skyflowInit = jest.fn();
+        let windowSpy = jest.spyOn(global, 'window', 'get');
+        windowSpy.mockImplementation(() => ({
+            parent: {
+                frames: {
+                    [`${checkbox_element}:controllerId:ERROR`]:{
+                        document:{
+                            getElementById:()=>({
+                                iFrameFormElement:element
+                            })
+                        }
+                    }
+                }
+            },
+            location: {
+                href: 'http://iframe.html'
+            }
+        }));
+
+        form.setClient(clientObj1)
+        form.setClientMetadata(metaData)
+        form.setContext(context)
+
+        const tokenizationEvent = on.mock.calls.filter((data) => data[0] === ELEMENT_EVENTS_TO_IFRAME.TOKENIZATION_REQUEST + 'controllerId');
+        const tokenizationCb = tokenizationEvent[0][1];
+        const cb2 = jest.fn();
+        tokenizationCb({...data,elementIds:[{elementId:checkbox_element,frameId:checkbox_element}]}, cb2);
+        setTimeout(() => {
+            expect(cb2.mock.calls[0][0].error).toBeDefined();
+            done()
+        }, 1000)
+        form.tokenize({...data,elementIds:[{elementId:checkbox_element,frameId:checkbox_element},{elementId:checkbox_element,frameId:checkbox_element}]}).then().catch( err => {
+            expect(err).toBeDefined();
+        })
+        windowSpy.mockImplementation(() => ({
+            parent: {
+                frames: [{
+                    name: collect_element,
+                    location: {
+                        href: 'http://iframe.html'
+                    },
+                    Skyflow: {
+                        init: skyflowInit
+                    }
+                }]
+            },
+            location: {
+                href: 'http://iframe.html'
+            }
+        }));
+    })
+
+    test('skyflowID error', (done) => {
         const form = new IFrameForm("controllerId", "", "ERROR");
         form.setClient(clientObj)
         form.setClientMetadata(metaData)
         form.setContext(context)
 
+        const element =  new IFrameFormElement(collect_element,"",{},context)
+
+        element.setValue("123")
+        element.tableName = "table"
+        element.state.name = collect_element
+        element.skyflowID = ''
+        const skyflowInit = jest.fn();
+        let windowSpy = jest.spyOn(global, 'window', 'get');
+        windowSpy.mockImplementation(() => ({
+            parent: {
+                frames: {
+                    [`${collect_element}:controllerId:ERROR`]:{
+                        document:{
+                            getElementById:()=>({
+                                iFrameFormElement:element
+                            })
+                        }
+                    }
+                }
+            },
+            location: {
+                href: 'http://iframe.html'
+            }
+        }));
         const tokenizationEvent = on.mock.calls.filter((data) => data[0] === ELEMENT_EVENTS_TO_IFRAME.TOKENIZATION_REQUEST + 'controllerId');
         const tokenizationCb = tokenizationEvent[0][1];
         const cb2 = jest.fn();
@@ -1047,12 +1669,95 @@ describe('test iframeForm collect method', () => {
                         col: '123',
                     }
                 }]
-            }
+            },
+            elementIds:[{elementId:collect_element,frameId:collect_element}]
         }, cb2)   
         setTimeout(() => {
             expect(cb2.mock.calls[0][0].error.message).toBeDefined()
             done()
         }, 1000)
+        windowSpy.mockImplementation(() => ({
+            parent: {
+                frames: [{
+                    name: collect_element,
+                    location: {
+                        href: 'http://iframe.html'
+                    },
+                    Skyflow: {
+                        init: skyflowInit
+                    }
+                }]
+            },
+            location: {
+                href: 'http://iframe.html'
+            }
+        }));
+    })
+
+    test('insert records duplicate error', (done) => {
+        const form = new IFrameForm("controllerId", "", "ERROR");
+        form.setClient(clientObj)
+        form.setClientMetadata(metaData)
+        form.setContext(context)
+
+        const element =  new IFrameFormElement(collect_element,"",{},context)
+
+        element.setValue("123")
+        element.tableName = "table"
+        element.state.name = collect_element
+        const skyflowInit = jest.fn();
+        let windowSpy = jest.spyOn(global, 'window', 'get');
+        windowSpy.mockImplementation(() => ({
+            parent: {
+                frames: {
+                    [`${collect_element}:controllerId:ERROR`]:{
+                        document:{
+                            getElementById:()=>({
+                                iFrameFormElement:element
+                            })
+                        }
+                    }
+                }
+            },
+            location: {
+                href: 'http://iframe.html'
+            }
+        }));
+        const tokenizationEvent = on.mock.calls.filter((data) => data[0] === ELEMENT_EVENTS_TO_IFRAME.TOKENIZATION_REQUEST + 'controllerId');
+        const tokenizationCb = tokenizationEvent[0][1];
+        const cb2 = jest.fn();
+        tokenizationCb({
+            additionalFields: {
+                records: [{
+                    table: 'table',
+                    fields: {
+                        col: '123',
+                        col: '123',
+                    }
+                }]
+            },
+            elementIds:[{elementId:collect_element,frameId:collect_element},{elementId:collect_element,frameId:collect_element}]
+        }, cb2)   
+        setTimeout(() => {
+            expect(cb2.mock.calls[0][0].error.message).toBeDefined()
+            done()
+        }, 1000)
+        windowSpy.mockImplementation(() => ({
+            parent: {
+                frames: [{
+                    name: collect_element,
+                    location: {
+                        href: 'http://iframe.html'
+                    },
+                    Skyflow: {
+                        init: skyflowInit
+                    }
+                }]
+            },
+            location: {
+                href: 'http://iframe.html'
+            }
+        }));
     })
     test('insert records with tokens as false', (done) => {
         const form = new IFrameForm("controllerId", "", "ERROR");
@@ -1060,15 +1765,55 @@ describe('test iframeForm collect method', () => {
         form.setClientMetadata(metaData)
         form.setContext(context)
 
+        const element =  new IFrameFormElement(collect_element,"",{},context)
+
+        element.setValue("123")
+        const skyflowInit = jest.fn();
+        let windowSpy = jest.spyOn(global, 'window', 'get');
+        windowSpy.mockImplementation(() => ({
+            parent: {
+                frames: {
+                    [`${collect_element}:controllerId:ERROR`]:{
+                        document:{
+                            getElementById:()=>({
+                                iFrameFormElement:element
+                            })
+                        }
+                    }
+                }
+            },
+            location: {
+                href: 'http://iframe.html'
+            }
+        }));
+
         const tokenizationEvent = on.mock.calls.filter((data) => data[0] === ELEMENT_EVENTS_TO_IFRAME.TOKENIZATION_REQUEST + 'controllerId');
         const tokenizationCb = tokenizationEvent[0][1];
         const cb2 = jest.fn();
-        tokenizationCb(data2, cb2);
+        tokenizationCb({...data2,
+            elementIds:[{elementId:collect_element,frameId:collect_element}]
+        }, cb2);
         setTimeout(() => {
             expect(cb2.mock.calls[0][0].records[0].table).toBe('pii_fields');
             expect(Object.keys(cb2.mock.calls[0][0].records[0]).length).toBe(2);
             done()
         }, 1000)
+        windowSpy.mockImplementation(() => ({
+            parent: {
+                frames: [{
+                    name: collect_element,
+                    location: {
+                        href: 'http://iframe.html'
+                    },
+                    Skyflow: {
+                        init: skyflowInit
+                    }
+                }]
+            },
+            location: {
+                href: 'http://iframe.html'
+            }
+        }));
     })
 
 })

--- a/tests/core/internal/iframe-form/iframe-form.test.js
+++ b/tests/core/internal/iframe-form/iframe-form.test.js
@@ -176,7 +176,7 @@ describe('test iframeFormelement', () => {
         const form = new IFrameForm("controllerId","",'ERROR')
         jest.spyOn(window,'parent','get').mockImplementation(()=>({
             frames:{
-                [`element:EXPIRATION_MONTH:${tableCol}:controllerId:ERROR`]:{
+                [`element:EXPIRATION_MONTH:${tableCol}:controllerId:ERROR:`]:{
                     document:{
                         getElementById:()=>({
                             iFrameFormElement:element
@@ -518,7 +518,8 @@ const data = {
         }]
     },
     tokens: true,
-    upsert: [{ table: '', column: '  ' }]
+    upsert: [{ table: '', column: '  ' }],
+    elementIds: []
 }
 const data2 = {
     additionalFields: {
@@ -669,7 +670,6 @@ describe('test iframeForm collect method', () => {
         const element = createFormElement(collect_element,undefined,undefined,true)
 
         const setErrorEvent = on.mock.calls.filter((data)=>data[0]===ELEMENT_EVENTS_TO_IFRAME.COLLECT_ELEMENT_SET_ERROR)
-        console.log("setErrorEvent",setErrorEvent)
         const setErrorCb = setErrorEvent[0][1]
 
         setErrorCb({isTriggerError:true,clientErrorText:"Error",name:collect_element})
@@ -681,7 +681,7 @@ describe('test iframeForm collect method', () => {
         windowSpy.mockImplementation(() => ({
             parent: {
                 frames: {
-                    [`${collect_element}:controllerId:ERROR`]:{
+                    [`${collect_element}:controllerId:ERROR:`]:{
                         document:{
                             getElementById:()=>({
                                 iFrameFormElement:element
@@ -697,7 +697,7 @@ describe('test iframeForm collect method', () => {
         tokenizationCb({...data,elementIds:[{elementId:collect_element,frameId:collect_element}]}, cb2)
 
         setTimeout(() => {
-            expect(cb2.mock.calls[0][0].error.message).toBeDefined()
+            expect(cb2.mock.calls[0][0].error.error.description).toBeDefined()
             done()
         }, 1000)
 
@@ -764,7 +764,7 @@ describe('test iframeForm collect method', () => {
         windowSpy.mockImplementation(() => ({
             parent: {
                 frames: {
-                    [`${collect_element}:controllerId:ERROR`]:{
+                    [`${collect_element}:controllerId:ERROR:`]:{
                         document:{
                             getElementById:()=>({
                                 iFrameFormElement:element
@@ -877,7 +877,7 @@ describe('test iframeForm collect method', () => {
         windowSpy.mockImplementation(() => ({
             parent: {
                 frames: {
-                    [`${collect_element}:controllerId:ERROR`]:{
+                    [`${collect_element}:controllerId:ERROR:`]:{
                         document:{
                             getElementById:()=>({
                                 iFrameFormElement:element
@@ -1001,7 +1001,7 @@ describe('test iframeForm collect method', () => {
         tokenizationCb(data, cb2)
 
         setTimeout(() => {
-            expect(cb2.mock.calls[0][0].error.message).toBeDefined()
+            expect(cb2.mock.calls[0][0].error.error.description).toBeDefined()
         }, 1000)
         element.setValue('123')
         const cb3 = jest.fn()
@@ -1081,7 +1081,7 @@ describe('test iframeForm collect method', () => {
         tokenizationCb(data, cb2)
 
         setTimeout(() => {
-            expect(cb2.mock.calls[0][0].error.message).toBeDefined()
+            expect(cb2.mock.calls[0][0].error.error.description).toBeDefined()
         }, 1000)
         element.setValue('123')
         const cb3 = jest.fn()
@@ -1151,7 +1151,7 @@ describe('test iframeForm collect method', () => {
         windowSpy.mockImplementation(() => ({
             parent: {
                 frames: {
-                    [`${collect_element}:controllerId:ERROR`]:{
+                    [`${collect_element}:controllerId:ERROR:`]:{
                         document:{
                             getElementById:()=>({
                                 iFrameFormElement:element
@@ -1249,7 +1249,7 @@ describe('test iframeForm collect method', () => {
         windowSpy.mockImplementation(() => ({
             parent: {
                 frames: {
-                    [`${collect_element}:controllerId:ERROR`]:{
+                    [`${collect_element}:controllerId:ERROR:`]:{
                         document:{
                             getElementById:()=>({
                                 iFrameFormElement:element
@@ -1294,7 +1294,7 @@ describe('test iframeForm collect method', () => {
         windowSpy.mockImplementation(() => ({
             parent: {
                 frames: {
-                    [`${collect_element}:controllerId:ERROR`]:{
+                    [`${collect_element}:controllerId:ERROR:`]:{
                         document:{
                             getElementById:()=>({
                                 iFrameFormElement:element
@@ -1357,7 +1357,7 @@ describe('test iframeForm collect method', () => {
         windowSpy.mockImplementation(() => ({
             parent: {
                 frames: {
-                    [`${collect_element}:controllerId:ERROR`]:{
+                    [`${collect_element}:controllerId:ERROR:`]:{
                         document:{
                             getElementById:()=>({
                                 iFrameFormElement:element
@@ -1413,7 +1413,7 @@ describe('test iframeForm collect method', () => {
         windowSpy.mockImplementation(() => ({
             parent: {
                 frames: {
-                    [`${collect_element}:controllerId:ERROR`]:{
+                    [`${collect_element}:controllerId:ERROR:`]:{
                         document:{
                             getElementById:()=>(undefined)
                         }
@@ -1466,7 +1466,7 @@ describe('test iframeForm collect method', () => {
         windowSpy.mockImplementation(() => ({
             parent: {
                 frames: {
-                    [`${collect_element}:controllerId:ERROR`]:{
+                    [`${collect_element}:controllerId:ERROR:`]:{
                         document:{
                             getElementById:()=>({
                                 iFrameFormElement:element
@@ -1523,7 +1523,7 @@ describe('test iframeForm collect method', () => {
         windowSpy.mockImplementation(() => ({
             parent: {
                 frames: {
-                    [`${collect_element}:controllerId:ERROR`]:{
+                    [`${collect_element}:controllerId:ERROR:`]:{
                         document:{
                             getElementById:()=>({
                                 iFrameFormElement:element
@@ -1580,7 +1580,7 @@ describe('test iframeForm collect method', () => {
         windowSpy.mockImplementation(() => ({
             parent: {
                 frames: {
-                    [`${checkbox_element}:controllerId:ERROR`]:{
+                    [`${checkbox_element}:controllerId:ERROR:`]:{
                         document:{
                             getElementById:()=>({
                                 iFrameFormElement:element
@@ -1644,7 +1644,7 @@ describe('test iframeForm collect method', () => {
         windowSpy.mockImplementation(() => ({
             parent: {
                 frames: {
-                    [`${collect_element}:controllerId:ERROR`]:{
+                    [`${collect_element}:controllerId:ERROR:`]:{
                         document:{
                             getElementById:()=>({
                                 iFrameFormElement:element
@@ -1710,7 +1710,7 @@ describe('test iframeForm collect method', () => {
         windowSpy.mockImplementation(() => ({
             parent: {
                 frames: {
-                    [`${collect_element}:controllerId:ERROR`]:{
+                    [`${collect_element}:controllerId:ERROR:`]:{
                         document:{
                             getElementById:()=>({
                                 iFrameFormElement:element
@@ -1773,7 +1773,7 @@ describe('test iframeForm collect method', () => {
         windowSpy.mockImplementation(() => ({
             parent: {
                 frames: {
-                    [`${collect_element}:controllerId:ERROR`]:{
+                    [`${collect_element}:controllerId:ERROR:`]:{
                         document:{
                             getElementById:()=>({
                                 iFrameFormElement:element
@@ -1972,7 +1972,6 @@ describe('test file Upload method', () => {
         fileUploadCb(fileData, cb2)
 
         setTimeout(() => {
-            console.log('cb2.mock.calls', cb2.mock.calls);
             expect(cb2.mock.calls[0][0].error).toBeDefined()
             done()
         }, 3000)
@@ -1989,7 +1988,6 @@ describe('test file Upload method', () => {
         fileUploadCb(fileData, cb3)
 
         setTimeout(() => {
-            console.log('cb3.mock.calls', cb3.mock.calls);
             expect(cb3.mock.calls[0][0].error).toBeDefined()
             done()
         }, 1000)

--- a/tests/core/internal/reveal/reveal-frame.test.js
+++ b/tests/core/internal/reveal/reveal-frame.test.js
@@ -67,9 +67,34 @@ describe("Reveal Frame Class",()=>{
     });
   });
 
+  test("init callback before reveal : without path",()=>{
+    const data = {
+      record:{
+        token:"1815-6223-1073-1425",
+        label:"Card Number",
+        altText:"xxxx-xxxx-xxxx-xxxx",
+        inputStyles:{
+          base:{
+            color:"red"
+          }
+        },
+        labelStyles:{
+          base:{
+            color:"black"
+          }
+        }
+      },
+      context: { logLevel: LogLevel.ERROR,env:Env.PROD}
+    }
+    defineUrl('http://localhost');
+    try{
+      RevealFrame.init()
+    }catch(e){
+      expect(e).toBeDefined()
+    }
+  });
+
   test("init callback before reveal",()=>{
-    const testFrame = RevealFrame.init();
-    // const onCb = jest.fn();
     const data = {
       record:{
         token:"1815-6223-1073-1425",
@@ -89,16 +114,12 @@ describe("Reveal Frame Class",()=>{
       context: { logLevel: LogLevel.ERROR,env:Env.PROD}
     }
     defineUrl('http://localhost/?' + btoa(JSON.stringify(data)));
+    const testFrame = RevealFrame.init();
     const emittedEventName = emitSpy.mock.calls[0][0];
-    const emitCb = emitSpy.mock.calls[0][2];
     expect(emittedEventName).toBe(ELEMENT_EVENTS_TO_IFRAME.REVEAL_FRAME_READY);
-    emitCb(data);
-
   });
 
   test("init callback after reveal with response value",()=>{
-    const testFrame = RevealFrame.init();
-    // const onCb = jest.fn();
     const data = {
       record:{
         token:"1815-6223-1073-1425",
@@ -118,6 +139,7 @@ describe("Reveal Frame Class",()=>{
       context: { logLevel: LogLevel.ERROR,env:Env.PROD}
     }
     defineUrl('http://localhost/?' + btoa(JSON.stringify(data)));
+    const testFrame = RevealFrame.init();
     const emittedEventName = emitSpy.mock.calls[0][0];
     const emitCb = emitSpy.mock.calls[0][2];
     expect(emittedEventName).toBe(ELEMENT_EVENTS_TO_IFRAME.REVEAL_FRAME_READY);
@@ -133,8 +155,6 @@ describe("Reveal Frame Class",()=>{
   });
 
   test("init callback after reveal with response value with mask value",()=>{
-    const testFrame = RevealFrame.init();
-    // const onCb = jest.fn();
     const data = {
       record:{
         token:"1815",
@@ -154,6 +174,8 @@ describe("Reveal Frame Class",()=>{
       },
       context: { logLevel: LogLevel.ERROR,env:Env.PROD}
     }
+    defineUrl('http://localhost/?' + btoa(JSON.stringify(data)));
+    const testFrame = RevealFrame.init();
     const emittedEventName = emitSpy.mock.calls[0][0];
     const emitCb = emitSpy.mock.calls[0][2];
     expect(emittedEventName).toBe(ELEMENT_EVENTS_TO_IFRAME.REVEAL_FRAME_READY);
@@ -167,8 +189,6 @@ describe("Reveal Frame Class",()=>{
     onRevealResponseCb({"1815":"1234"})
   });
   test("init callback after reveal without value",()=>{
-    const testFrame = RevealFrame.init();
-    // const onCb = jest.fn();
     const data = {
       record:{
         token:"1815-6223-1073-1425",
@@ -192,6 +212,8 @@ describe("Reveal Frame Class",()=>{
       },
       context: { logLevel: LogLevel.ERROR,env:Env.PROD}
     }
+    defineUrl('http://localhost/?' + btoa(JSON.stringify(data)));
+    const testFrame = RevealFrame.init();
     const emittedEventName = emitSpy.mock.calls[0][0];
     const emitCb = emitSpy.mock.calls[0][2];
     expect(emittedEventName).toBe(ELEMENT_EVENTS_TO_IFRAME.REVEAL_FRAME_READY);
@@ -207,8 +229,6 @@ describe("Reveal Frame Class",()=>{
   });
 
   test("reveal set error",()=>{
-    const testFrame = RevealFrame.init();
-    // const onCb = jest.fn();
     const data = {
       record:{
         token:"1815-6223-1073-1425",
@@ -235,6 +255,8 @@ describe("Reveal Frame Class",()=>{
       },
       context: { logLevel: LogLevel.ERROR,env:Env.PROD}
     }
+    defineUrl('http://localhost/?' + btoa(JSON.stringify(data)));
+    const testFrame = RevealFrame.init();
     const emittedEventName = emitSpy.mock.calls[0][0];
     const emitCb = emitSpy.mock.calls[0][2];
     expect(emittedEventName).toBe(ELEMENT_EVENTS_TO_IFRAME.REVEAL_FRAME_READY);
@@ -253,50 +275,6 @@ describe("Reveal Frame Class",()=>{
   });
 
   test("reveal reset error",()=>{
-    const testFrame = RevealFrame.init();
-    // const onCb = jest.fn();
-    const data = {
-      record:{
-        token:"1815-6223-1073-1425",
-        label:"Card Number",
-        altText:"xxxx-xxxx-xxxx-xxxx",
-        inputStyles:{
-          base:{
-            color:"red"
-          }
-        },
-        labelStyles:{
-          base:{
-            color:"black"
-          }
-        },
-        errorTextStyles:{
-          base:{
-            color:"red"
-          }
-        }
-      },
-      context: { logLevel: LogLevel.ERROR,env:Env.PROD}
-    }
-    const emittedEventName = emitSpy.mock.calls[0][0];
-    const emitCb = emitSpy.mock.calls[0][2];
-    expect(emittedEventName).toBe(ELEMENT_EVENTS_TO_IFRAME.REVEAL_FRAME_READY);
-    emitCb(data);
-
-    // reveal response ready
-    const onRevealResponseName = on.mock.calls[1][0];
-    // undefined since with jest window.name will be emptyString("") 
-    expect(onRevealResponseName).toBe(ELEMENT_EVENTS_TO_IFRAME.REVEAL_ELEMENT_SET_ERROR);
-    const onRevealResponseCb = on.mock.calls[1][1];
-    onRevealResponseCb({
-      name: "",
-      isTriggerError: false,
-    });
-    
-  });
-  test("reveal set token",()=>{
-    const testFrame = RevealFrame.init();
-    // const onCb = jest.fn();
     const data = {
       record:{
         token:"1815-6223-1073-1425",
@@ -321,24 +299,24 @@ describe("Reveal Frame Class",()=>{
       context: { logLevel: LogLevel.ERROR,env:Env.PROD}
     }
     defineUrl('http://localhost/?' + btoa(JSON.stringify(data)));
+    const testFrame = RevealFrame.init();
     const emittedEventName = emitSpy.mock.calls[0][0];
     const emitCb = emitSpy.mock.calls[0][2];
     expect(emittedEventName).toBe(ELEMENT_EVENTS_TO_IFRAME.REVEAL_FRAME_READY);
     emitCb(data);
-    const onRevealResponseName = on.mock.calls[2][0];
+
+    // reveal response ready
+    const onRevealResponseName = on.mock.calls[1][0];
     // undefined since with jest window.name will be emptyString("") 
-    expect(onRevealResponseName).toBe(ELEMENT_EVENTS_TO_IFRAME.REVEAL_ELEMENT_UPDATE_OPTIONS);
-    const onRevealResponseCb = on.mock.calls[2][1];
+    expect(onRevealResponseName).toBe(ELEMENT_EVENTS_TO_IFRAME.REVEAL_ELEMENT_SET_ERROR);
+    const onRevealResponseCb = on.mock.calls[1][1];
     onRevealResponseCb({
       name: "",
-      updateType:REVEAL_ELEMENT_OPTIONS_TYPES.TOKEN,
-      updatedValue:"121-43sfsdaf31-3sa1a321"
+      isTriggerError: false,
     });
     
   });
-  test("reveal set altText",()=>{
-    const testFrame = RevealFrame.init();
-    // const onCb = jest.fn();
+  test("reveal set token",()=>{
     const data = {
       record:{
         token:"1815-6223-1073-1425",
@@ -362,6 +340,49 @@ describe("Reveal Frame Class",()=>{
       },
       context: { logLevel: LogLevel.ERROR,env:Env.PROD}
     }
+    defineUrl('http://localhost/?' + btoa(JSON.stringify(data)));
+    const testFrame = RevealFrame.init();
+    const emittedEventName = emitSpy.mock.calls[0][0];
+    const emitCb = emitSpy.mock.calls[0][2];
+    expect(emittedEventName).toBe(ELEMENT_EVENTS_TO_IFRAME.REVEAL_FRAME_READY);
+    emitCb(data);
+    const onRevealResponseName = on.mock.calls[2][0];
+    // undefined since with jest window.name will be emptyString("") 
+    expect(onRevealResponseName).toBe(ELEMENT_EVENTS_TO_IFRAME.REVEAL_ELEMENT_UPDATE_OPTIONS);
+    const onRevealResponseCb = on.mock.calls[2][1];
+    onRevealResponseCb({
+      name: "",
+      updateType:REVEAL_ELEMENT_OPTIONS_TYPES.TOKEN,
+      updatedValue:"121-43sfsdaf31-3sa1a321"
+    });
+    
+  });
+  test("reveal set altText",()=>{
+    const data = {
+      record:{
+        token:"1815-6223-1073-1425",
+        label:"Card Number",
+        altText:"xxxx-xxxx-xxxx-xxxx",
+        inputStyles:{
+          base:{
+            color:"red"
+          }
+        },
+        labelStyles:{
+          base:{
+            color:"black"
+          }
+        },
+        errorTextStyles:{
+          base:{
+            color:"red"
+          }
+        }
+      },
+      context: { logLevel: LogLevel.ERROR,env:Env.PROD}
+    }
+    defineUrl('http://localhost/?' + btoa(JSON.stringify(data)));
+    const testFrame = RevealFrame.init();
     const emittedEventName = emitSpy.mock.calls[0][0];
     const emitCb = emitSpy.mock.calls[0][2];
     expect(emittedEventName).toBe(ELEMENT_EVENTS_TO_IFRAME.REVEAL_FRAME_READY);
@@ -379,8 +400,6 @@ describe("Reveal Frame Class",()=>{
     
   });
   test("reveal clearAltText",()=>{
-    const testFrame = RevealFrame.init();
-    // const onCb = jest.fn();
     const data = {
       record:{
         token:"1815-6223-1073-1425",
@@ -404,6 +423,8 @@ describe("Reveal Frame Class",()=>{
       },
       context: { logLevel: LogLevel.ERROR,env:Env.PROD}
     }
+    defineUrl('http://localhost/?' + btoa(JSON.stringify(data)));
+    const testFrame = RevealFrame.init();
     const emittedEventName = emitSpy.mock.calls[0][0];
     const emitCb = emitSpy.mock.calls[0][2];
     expect(emittedEventName).toBe(ELEMENT_EVENTS_TO_IFRAME.REVEAL_FRAME_READY);
@@ -421,8 +442,6 @@ describe("Reveal Frame Class",()=>{
     
   });
   test("copy icon in reveal elements",()=>{
-    const testFrame = RevealFrame.init();
-    // const onCb = jest.fn();
     const data = {
       record:{
         token:"1815-6223-1073-1425",
@@ -455,6 +474,8 @@ describe("Reveal Frame Class",()=>{
       },
       context: { logLevel: LogLevel.ERROR,env:Env.PROD}
     }
+    defineUrl('http://localhost/?' + btoa(JSON.stringify(data)));
+    const testFrame = RevealFrame.init();
     const emittedEventName = emitSpy.mock.calls[0][0];
     const emitCb = emitSpy.mock.calls[0][2];
     expect(emittedEventName).toBe(ELEMENT_EVENTS_TO_IFRAME.REVEAL_FRAME_READY);
@@ -462,8 +483,6 @@ describe("Reveal Frame Class",()=>{
   })
 
   test("global style variant in reveal elements",()=>{
-    const testFrame = RevealFrame.init();
-    // const onCb = jest.fn();
     const data = {
       record:{
         token:"1815-6223-1073-1425",
@@ -498,6 +517,7 @@ describe("Reveal Frame Class",()=>{
       context: { logLevel: LogLevel.ERROR,env:Env.PROD}
     }
     defineUrl('http://localhost/?' + btoa(JSON.stringify(data)));
+    const testFrame = RevealFrame.init();
     const emittedEventName = emitSpy.mock.calls[0][0];
     const emitCb = emitSpy.mock.calls[0][2];
     expect(emittedEventName).toBe(ELEMENT_EVENTS_TO_IFRAME.REVEAL_FRAME_READY);

--- a/tests/core/internal/reveal/reveal-frame.test.js
+++ b/tests/core/internal/reveal/reveal-frame.test.js
@@ -42,6 +42,16 @@ const testRecord = {
 //     expect(_on).toHaveBeenCalledTimes(2);
 //   });
 // });
+global.window = Object.create(window);
+const defineUrl = (url) => {
+  Object.defineProperty(window, "location", {
+    value: {
+      href: url,
+    },
+    writable: true,
+  });
+};
+
 const on = jest.fn();
 const off = jest.fn();
 describe("Reveal Frame Class",()=>{
@@ -78,6 +88,7 @@ describe("Reveal Frame Class",()=>{
       },
       context: { logLevel: LogLevel.ERROR,env:Env.PROD}
     }
+    defineUrl('http://localhost/?' + btoa(JSON.stringify(data)));
     const emittedEventName = emitSpy.mock.calls[0][0];
     const emitCb = emitSpy.mock.calls[0][2];
     expect(emittedEventName).toBe(ELEMENT_EVENTS_TO_IFRAME.REVEAL_FRAME_READY);
@@ -106,10 +117,11 @@ describe("Reveal Frame Class",()=>{
       },
       context: { logLevel: LogLevel.ERROR,env:Env.PROD}
     }
+    defineUrl('http://localhost/?' + btoa(JSON.stringify(data)));
     const emittedEventName = emitSpy.mock.calls[0][0];
     const emitCb = emitSpy.mock.calls[0][2];
     expect(emittedEventName).toBe(ELEMENT_EVENTS_TO_IFRAME.REVEAL_FRAME_READY);
-    emitCb(data);
+    // emitCb(data);
 
     // reveal response ready
     const onRevealResponseName = on.mock.calls[0][0];
@@ -308,6 +320,7 @@ describe("Reveal Frame Class",()=>{
       },
       context: { logLevel: LogLevel.ERROR,env:Env.PROD}
     }
+    defineUrl('http://localhost/?' + btoa(JSON.stringify(data)));
     const emittedEventName = emitSpy.mock.calls[0][0];
     const emitCb = emitSpy.mock.calls[0][2];
     expect(emittedEventName).toBe(ELEMENT_EVENTS_TO_IFRAME.REVEAL_FRAME_READY);
@@ -484,6 +497,7 @@ describe("Reveal Frame Class",()=>{
       },
       context: { logLevel: LogLevel.ERROR,env:Env.PROD}
     }
+    defineUrl('http://localhost/?' + btoa(JSON.stringify(data)));
     const emittedEventName = emitSpy.mock.calls[0][0];
     const emitCb = emitSpy.mock.calls[0][2];
     expect(emittedEventName).toBe(ELEMENT_EVENTS_TO_IFRAME.REVEAL_FRAME_READY);


### PR DESCRIPTION
**Why**
- We are currently rendering element based on event FRAME_READY, after reading from bus and start applying config.

**Outcome**
- Apply config right away after mount, not to be waiting on event bus for FRAME_READY event
- Achieve via encoding(BASE64) config in the url and decoding the same and applying the config 