### PR TITLE
SK-1980 Add card brand choice enhancements

### DIFF
--- a/src/core/internal/index.ts
+++ b/src/core/internal/index.ts
@@ -417,9 +417,9 @@ export class FrameElement {
         if (cardMetadata?.scheme) {
           if (Array.isArray(cardMetadata.scheme) && cardMetadata.scheme.length >= 2) {
             this.appendDropdown(cardMetadata.scheme);
-            if (this.domImg) {
-              this.domImg.src = CARD_ENCODED_ICONS[cardMetadata.scheme[0]]
-              || CARD_ENCODED_ICONS.DEFAULT;
+            if (this.domImg && CARD_ENCODED_ICONS[cardMetadata.scheme[0]]) {
+              this.domImg.src = CARD_ENCODED_ICONS[cardMetadata.scheme[0]];
+              // Fire change event to update selectedCardScheme
               this.iFrameFormElement.onDropdownSelect(cardMetadata.scheme[0]);
             }
           } else if (this.dropdownIcon && this.dropdownSelect && this.domInput && this.domImg) {

--- a/src/core/internal/index.ts
+++ b/src/core/internal/index.ts
@@ -417,6 +417,11 @@ export class FrameElement {
         if (cardMetadata?.scheme) {
           if (Array.isArray(cardMetadata.scheme) && cardMetadata.scheme.length >= 2) {
             this.appendDropdown(cardMetadata.scheme);
+            if (this.domImg) {
+              this.domImg.src = CARD_ENCODED_ICONS[cardMetadata.scheme[0]]
+              || CARD_ENCODED_ICONS.DEFAULT;
+              this.iFrameFormElement.onDropdownSelect(cardMetadata.scheme[0]);
+            }
           } else if (this.dropdownIcon && this.dropdownSelect && this.domInput && this.domImg) {
             this.domInput.style.textIndent = '36px';
             this.iFrameFormElement.onDropdownSelect('');

--- a/tests/core/internal/frame-controller.test.js
+++ b/tests/core/internal/frame-controller.test.js
@@ -22,7 +22,8 @@ import {
   CardType,
   ELEMENTS,
   CUSTOM_ROW_ID_ATTRIBUTE,
-  INPUT_KEYBOARD_EVENTS
+  INPUT_KEYBOARD_EVENTS,
+  CARD_ENCODED_ICONS
 } from '../../../src/core/constants';
 import {
   detectCardType
@@ -273,16 +274,33 @@ describe('test frame controller', () => {
     expect(div.getElementsByTagName('select').length).toBe(1);
     expect(div.getElementsByTagName('option').length).toBe(3);
 
+    // Verfiy updated icon, should be fist option provided in cardMetadata scheme
+    expect(element.domImg.src).toContain(CARD_ENCODED_ICONS.VISA); 
+
     const select = div.getElementsByTagName('select')[0];
     select.value = CardType.CARTES_BANCAIRES;
     select.dispatchEvent(new Event('change'))
     expect(select.selectedIndex).toBe(2) // cartes bancaries
+    expect(element.domImg.src).toContain(CARD_ENCODED_ICONS["CARTES BANCAIRES"]); // Verify updated icon
 
     select.value = CardType.VISA;
     select.dispatchEvent(new Event('change'))
     expect(select.selectedIndex).toBe(1) // visa
+    expect(element.domImg.src).toContain(CARD_ENCODED_ICONS.VISA); // Verify updated icon
 
     expect(div.getElementsByTagName('img').length).toBe(2); // dropdown + card icon
+
+    setCb[0][1]({
+      label:'cardnumber',
+      options: {
+        cardMetadata:{
+          scheme:['visa',CardType.CARTES_BANCAIRES]
+        }
+      },
+    });
+
+    // Verfiy updated icon, should be default since fist option provided in cardMetadata scheme is wrong
+    expect(element.domImg.src).toContain(CARD_ENCODED_ICONS.DEFAULT); 
 
     setCb[0][1]({
       label:'cardnumber',
@@ -295,6 +313,62 @@ describe('test frame controller', () => {
 
     expect(div.getElementsByTagName('select').length).toBe(0);
     expect(div.getElementsByTagName('img').length).toBe(1); // only cardicon
+
+    element.setupInputField();
+  });
+
+  test('FrameElement constructor with card number should not create card choice dropdown, when enableCardIcon is false', () => {
+    const cardElement = `element:CARD_NUMBER:${tableCol}`;
+    const div = document.createElement('div');
+
+    const formElement = new IFrameFormElement(cardElement, {}, context);
+    const element = new FrameElement(formElement, {
+      label: 'label',
+      enableCardIcon:false,
+      inputStyles:{...inputStyles,cardIcon:{left:'34px'},dropdown:{'background-color':'green'},dropdownIcon:{'left':'36px'}},
+      labelStyles,
+      errorTextStyles,
+    }, div);
+
+    const inst = EventEmitter.mock.instances[0];
+    const onSpy = inst.on.mock.calls;
+
+    const focusCb = onSpy
+      .filter((data) => data[0] === ELEMENT_EVENTS_TO_CLIENT.FOCUS);
+
+    focusCb[0][1](state);
+
+    const blurCb = onSpy
+      .filter((data) => data[0] === ELEMENT_EVENTS_TO_CLIENT.BLUR);
+
+
+    blurCb[0][1](state);
+
+    blurCb[0][1]({
+      ...state,
+      isValid: false,
+      isEmpty: false,
+    });
+
+    const changeCb = onSpy
+      .filter((data) => data[0] === ELEMENT_EVENTS_TO_CLIENT.CHANGE);
+
+    changeCb[0][1](state);
+
+    const setCb = onSpy
+      .filter((data) => data[0] === ELEMENT_EVENTS_TO_IFRAME.SET_VALUE);
+    setCb[0][1]({
+      label:'cardnumber',
+      options: {
+        cardMetadata:{
+          scheme:[CardType.VISA,CardType.CARTES_BANCAIRES]
+        }
+      },
+    });
+    expect(div.getElementsByTagName('select')).toBeDefined();
+
+    // Card image should not exist
+    expect(element.domImg).not.toBeDefined();
 
     element.setupInputField();
   });

--- a/tests/core/internal/frame-controller.test.js
+++ b/tests/core/internal/frame-controller.test.js
@@ -299,7 +299,7 @@ describe('test frame controller', () => {
       },
     });
 
-    // Verfiy updated icon, should be default since fist option provided in cardMetadata scheme is wrong
+    // Should be SDK detected card type since fist option provided in cardMetadata scheme is not supported
     expect(element.domImg.src).toContain(CARD_ENCODED_ICONS.DEFAULT); 
 
     setCb[0][1]({


### PR DESCRIPTION
This PR contains changes for enhancing card brand choice behaviour
## Why
- The card brand choice behaviour required some enhancements.
- Now, the card icon for first option provided in `scheme` will be rendered in UI.

## Goal
- This gives the flexibility to control the overall UX of card brand choice selection to the users.

## Testing
- Tested the changes manually
- Added and modified existing unit tests to cover new changes