### PR TITLE
SK-637: add usage notes for running script tag samples

### DIFF
--- a/samples/README.md
+++ b/samples/README.md
@@ -102,6 +102,8 @@ This sample shows you how to use event listeners with Skyflow Elements.
 
 From your browser, navigate to `http://localhost:8000/` to view the page.
 
+> **Note:** This HTML file must be served via a web server for the script-tag-based Skyflow sample to work correctly. Opening the file directly in a browser (using the `file://` protocol) may prevent the SDK from loading as expected. You can use a simple local server like `live-server` to run the file.
+
 ### Skyflow-Elements
 This sample shows you how to collect and reveal data with Skyflow Elements.
 


### PR DESCRIPTION
## Why
- Why are you making the change?
To inform customers on how to properly run the JS script-tag sample.

- What is the intent behind making the change?
To fix confusion around the correct method of running the sample, ensuring customers do not try to open the HTML file directly from their local file system.

## Goal
- What is the intended outcome?
Customers will now understand they must use a local web server to run the JS script-tag sample, using the note provided.

## Testing
- How was the code tested?
This is just a README update; no code changes or testing were required.