### PR TITLE
Add function overloads for `Skyflow.container`

### DIFF
--- a/src/skyflow.ts
+++ b/src/skyflow.ts
@@ -159,6 +159,9 @@ class Skyflow {
     return skyflow;
   }
 
+  container(type: ContainerType.COLLECT, options?: Record<string, any>): CollectContainer;
+  container(type: ContainerType.COMPOSABLE, options?: Record<string, any>): ComposableContainer;
+  container(type: ContainerType.REVEAL, options?: Record<string, any>): RevealContainer;
   container(type: ContainerType, options?: Record<string, any>) {
     switch (type) {
       case ContainerType.COLLECT: {


### PR DESCRIPTION
This makes the types more accurate