### PR TITLE
SK-2102 Add typescript public intefaces for JS SDK

### DIFF
--- a/src/core/external/collect/collect-container.ts
+++ b/src/core/external/collect/collect-container.ts
@@ -2,7 +2,6 @@
 Copyright (c) 2022 Skyflow, Inc.
 */
 import bus from 'framebus';
-import { IUpsertOptions } from '../../../core-utils/collect';
 import iframer, { setAttributes, getIframeSrc, setStyles } from '../../../iframe-libs/iframer';
 import deepClone from '../../../libs/deep-clone';
 import {
@@ -12,7 +11,12 @@ import SkyflowError from '../../../libs/skyflow-error';
 import uuid from '../../../libs/uuid';
 import { ContainerType } from '../../../skyflow';
 import {
-  IValidationRule, IInsertRecordInput, Context, MessageType,
+  Context, MessageType,
+  CollectElementInput,
+  CollectElementOptions,
+  CollectResponse,
+  ICollectOptions,
+  UploadFilesResponse,
 } from '../../../utils/common';
 import SKYFLOW_ERROR_CODE from '../../../utils/constants';
 import logs from '../../../utils/logs';
@@ -24,7 +28,7 @@ import {
   validateBooleanOptions,
 } from '../../../utils/validators';
 import {
-  ElementType, COLLECT_FRAME_CONTROLLER,
+  COLLECT_FRAME_CONTROLLER,
   CONTROLLER_STYLES, ELEMENT_EVENTS_TO_IFRAME,
   ELEMENTS, FRAME_ELEMENT,
   COLLECT_TYPES,
@@ -34,25 +38,6 @@ import CollectElement from './collect-element';
 import EventEmitter from '../../../event-emitter';
 import properties from '../../../properties';
 
-export interface CollectElementInput {
-  table?: string;
-  column?: string;
-  inputStyles?: object;
-  label?: string;
-  labelStyles?: object;
-  errorTextStyles?: object;
-  placeholder?: string;
-  type: ElementType;
-  altText?: string;
-  validations?: IValidationRule[]
-  skyflowID?: string;
-}
-
-interface ICollectOptions {
-  tokens?: boolean;
-  additionalFields?: IInsertRecordInput;
-  upsert?: Array<IUpsertOptions>
-}
 const CLASS_NAME = 'CollectContainer';
 class CollectContainer extends Container {
   #containerId: string;
@@ -110,7 +95,7 @@ class CollectContainer extends Container {
     this.#isMounted = true;
   }
 
-  create = (input: CollectElementInput, options: any = {
+  create = (input: CollectElementInput, options: CollectElementOptions = {
     required: false,
   }) => {
     validateCollectElementInput(input, this.#context.logLevel);
@@ -217,7 +202,7 @@ class CollectContainer extends Container {
       elements.forEach((iElement) => {
         const name = iElement.elementName;
         if (!this.#elements[name]) {
-          this.#elements[name] = this.create(iElement.elementType, element);
+          this.#elements[name] = this.create(iElement.elementType, iElement);
         } else {
           this.#elements[name].updateElementGroup(iElement);
         }
@@ -256,7 +241,7 @@ class CollectContainer extends Container {
     return false;
   };
 
-  collect = (options: ICollectOptions = { tokens: true }) :Promise<any> => {
+  collect = (options: ICollectOptions = { tokens: true }): Promise<CollectResponse> => {
     this.#isSkyflowFrameReady = this.#metaData.skyflowContainer.isControllerFrameReady;
     if (this.#isSkyflowFrameReady) {
       // eslint-disable-next-line @typescript-eslint/no-shadow
@@ -389,7 +374,7 @@ class CollectContainer extends Container {
     });
   };
 
-  uploadFiles = (options) :Promise<any> => {
+  uploadFiles = (options: ICollectOptions) :Promise<UploadFilesResponse> => {
     this.#isSkyflowFrameReady = this.#metaData.skyflowContainer.isControllerFrameReady;
     if (this.#isSkyflowFrameReady) {
       return new Promise((resolve, reject) => {

--- a/src/core/external/collect/collect-element.ts
+++ b/src/core/external/collect/collect-element.ts
@@ -27,6 +27,7 @@ import SkyflowError from '../../../libs/skyflow-error';
 import SKYFLOW_ERROR_CODE from '../../../utils/constants';
 import logs from '../../../utils/logs';
 import {
+  CollectElementInput,
   Context, Env, EventName, MessageType,
 } from '../../../utils/common';
 import {
@@ -197,7 +198,7 @@ class CollectElement extends SkyflowElement {
 
   getID = () => this.#elementId;
 
-  mount = (domElement) => {
+  mount = (domElement: HTMLElement | string) => {
     if (!domElement) {
       throw new SkyflowError(SKYFLOW_ERROR_CODE.EMPTY_ELEMENT_IN_MOUNT, ['CollectElement'], true);
     }
@@ -338,7 +339,7 @@ class CollectElement extends SkyflowElement {
     });
   };
 
-  update = (options) => {
+  update = (options: CollectElementInput) => {
     this.#isUpdateCalled = true;
     if (this.#mounted) {
       options.validations = formatValidations(options.validations);
@@ -417,7 +418,7 @@ class CollectElement extends SkyflowElement {
 
   // listening to element events and error messages on iframe
   // todo: off methods
-  on(eventName: string, handler) {
+  on(eventName: string, handler: Function) {
     if (!Object.values(ELEMENT_EVENTS_TO_CLIENT).includes(eventName)) {
       throw new SkyflowError(SKYFLOW_ERROR_CODE.INVALID_EVENT_LISTENER, [], true);
     }

--- a/src/core/external/collect/compose-collect-element.ts
+++ b/src/core/external/collect/compose-collect-element.ts
@@ -2,7 +2,7 @@ import EventEmitter from '../../../event-emitter';
 import { formatValidations } from '../../../libs/element-options';
 import SkyflowError from '../../../libs/skyflow-error';
 import { ContainerType } from '../../../skyflow';
-import { EventName } from '../../../utils/common';
+import { CollectElementInput, EventName } from '../../../utils/common';
 import SKYFLOW_ERROR_CODE from '../../../utils/constants';
 import { ELEMENT_EVENTS_TO_CLIENT, ELEMENT_EVENTS_TO_IFRAME, ElementType } from '../../constants';
 
@@ -29,7 +29,7 @@ class ComposableElement {
     });
   }
 
-  on(eventName: string, handler: any) {
+  on(eventName: string, handler: Function) {
     if (!Object.values(ELEMENT_EVENTS_TO_CLIENT).includes(eventName)) {
       throw new SkyflowError(
         SKYFLOW_ERROR_CODE.INVALID_EVENT_LISTENER,
@@ -73,7 +73,7 @@ class ComposableElement {
     return this.#elementName;
   }
 
-  update = (options) => {
+  update = (options:CollectElementInput) => {
     this.#isUpdateCalled = true;
     if (this.#isMounted) {
       options.validations = formatValidations(options.validations);

--- a/src/core/external/reveal/reveal-element.ts
+++ b/src/core/external/reveal/reveal-element.ts
@@ -101,7 +101,7 @@ class RevealElement extends SkyflowElement {
     return this.#elementId;
   }
 
-  mount(domElementSelector) {
+  mount(domElementSelector: HTMLElement | string) {
     if (!domElementSelector) {
       throw new SkyflowError(SKYFLOW_ERROR_CODE.EMPTY_ELEMENT_IN_MOUNT, ['RevealElement'], true);
     }
@@ -437,7 +437,7 @@ class RevealElement extends SkyflowElement {
     this.#iframe.unmount();
   }
 
-  update(options) {
+  update(options: IRevealElementInput) {
     this.#recordData = {
       ...this.#recordData,
       ...options,

--- a/src/core/external/skyflow-container.ts
+++ b/src/core/external/skyflow-container.ts
@@ -39,6 +39,12 @@ import {
   IDeleteOptions,
   IDeleteRecordInput,
   IGetOptions,
+  InsertResponse,
+  GetByIdResponse,
+  GetResponse,
+  DeleteResponse,
+  IInsertRecordInput,
+  DetokenizeResponse,
 } from '../../utils/common';
 
 const CLASS_NAME = 'SkyflowContainer';
@@ -82,7 +88,7 @@ class SkyflowContainer {
       this.#context.logLevel);
   }
 
-  detokenize(detokenizeInput: IDetokenizeInput): Promise<any> {
+  detokenize(detokenizeInput: IDetokenizeInput): Promise<DetokenizeResponse> {
     if (this.isControllerFrameReady) {
       return new Promise((resolve, reject) => {
         try {
@@ -147,7 +153,7 @@ class SkyflowContainer {
     });
   }
 
-  insert(records, options?:IInsertOptions): Promise<any> {
+  insert(records: IInsertRecordInput, options?:IInsertOptions): Promise<InsertResponse> {
     if (this.isControllerFrameReady) {
       return new Promise((resolve, reject) => {
         validateInitConfig(this.#client.config);
@@ -236,7 +242,7 @@ class SkyflowContainer {
     });
   }
 
-  getById(getByIdInput: IGetByIdInput) {
+  getById(getByIdInput: IGetByIdInput): Promise<GetByIdResponse> {
     if (this.isControllerFrameReady) {
       return new Promise((resolve, reject) => {
         validateInitConfig(this.#client.config);
@@ -304,7 +310,7 @@ class SkyflowContainer {
     });
   }
 
-  get(getInput: IGetInput, options?: IGetOptions) {
+  get(getInput: IGetInput, options?: IGetOptions): Promise<GetResponse> {
     if (this.isControllerFrameReady) {
       return new Promise((resolve, reject) => {
         validateInitConfig(this.#client.config);
@@ -372,7 +378,7 @@ class SkyflowContainer {
     });
   }
 
-  delete(records: IDeleteRecordInput, options?: IDeleteOptions) {
+  delete(records: IDeleteRecordInput, options?: IDeleteOptions): Promise<DeleteResponse> {
     if (this.isControllerFrameReady) {
       return new Promise((resolve, reject) => {
         validateInitConfig(this.#client.config);

--- a/src/index-node.ts
+++ b/src/index-node.ts
@@ -3,4 +3,37 @@ Copyright (c) 2022 Skyflow, Inc.
 */
 import Skyflow from './skyflow';
 
+export {
+  IInsertRecordInput,
+  IInsertOptions,
+  InsertResponse,
+  IDetokenizeInput,
+  DetokenizeResponse,
+  IDeleteRecordInput,
+  IDeleteOptions,
+  DeleteResponse,
+  IGetInput,
+  IGetOptions,
+  GetResponse,
+  IGetByIdInput,
+  GetByIdResponse,
+  ContainerOptions,
+  CollectElementInput,
+  CollectElementOptions,
+  ICollectOptions,
+  CollectResponse,
+  UploadFilesResponse,
+  CardMetadata,
+  InputStyles,
+  LabelStyles,
+  ErrorTextStyles,
+} from './utils/common';
+
+export {
+  IRevealElementInput,
+  IRevealElementOptions,
+} from './core/external/reveal/reveal-container';
+
+export { ThreeDSBrowserDetails } from './core/external/threeds/threeds';
+
 export default Skyflow;

--- a/src/index-node.ts
+++ b/src/index-node.ts
@@ -27,6 +27,7 @@ export {
   InputStyles,
   LabelStyles,
   ErrorTextStyles,
+  RedactionType,
 } from './utils/common';
 
 export {
@@ -35,5 +36,19 @@ export {
 } from './core/external/reveal/reveal-container';
 
 export { ThreeDSBrowserDetails } from './core/external/threeds/threeds';
+
+export {
+  CardType,
+  ElementType,
+} from './core/constants';
+
+export { ContainerType, ISkyflow } from './skyflow';
+
+export { default as CollectElement } from './core/external/collect/collect-element';
+export { default as CollectContainer } from './core/external/collect/collect-container';
+export { default as ComposableContainer } from './core/external/collect/compose-collect-container';
+export { default as RevealElement } from './core/external/reveal/reveal-element';
+export { default as RevealContainer } from './core/external/reveal/reveal-container';
+export { default as ThreeDS } from './core/external/threeds/threeds';
 
 export default Skyflow;

--- a/src/skyflow.ts
+++ b/src/skyflow.ts
@@ -21,7 +21,6 @@ import SkyflowError from './libs/skyflow-error';
 import logs from './utils/logs';
 import SKYFLOW_ERROR_CODE from './utils/constants';
 import {
-  IRevealResponseType,
   RequestMethod,
   IInsertRecordInput,
   IDetokenizeInput,
@@ -37,6 +36,12 @@ import {
   IDeleteRecordInput,
   IDeleteOptions,
   IGetOptions,
+  InsertResponse,
+  GetResponse,
+  GetByIdResponse,
+  DeleteResponse,
+  ContainerOptions,
+  DetokenizeResponse,
 } from './utils/common';
 import { formatVaultURL, checkAndSetForCustomUrl } from './utils/helpers';
 import ComposableContainer from './core/external/collect/compose-collect-container';
@@ -159,10 +164,10 @@ class Skyflow {
     return skyflow;
   }
 
-  container(type: ContainerType.COLLECT, options?: Record<string, any>): CollectContainer;
-  container(type: ContainerType.COMPOSABLE, options?: Record<string, any>): ComposableContainer;
-  container(type: ContainerType.REVEAL, options?: Record<string, any>): RevealContainer;
-  container(type: ContainerType, options?: Record<string, any>) {
+  container(type: ContainerType.COLLECT, options?: ContainerOptions): CollectContainer;
+  container(type: ContainerType.COMPOSABLE, options?: ContainerOptions): ComposableContainer;
+  container(type: ContainerType.REVEAL, options?: ContainerOptions): RevealContainer;
+  container(type: ContainerType, options?: ContainerOptions) {
     switch (type) {
       case ContainerType.COLLECT: {
         const collectContainer = new CollectContainer(options, {
@@ -219,32 +224,32 @@ class Skyflow {
   insert(
     records: IInsertRecordInput,
     options?: IInsertOptions,
-  ) {
+  ): Promise<InsertResponse> {
     printLog(parameterizedString(logs.infoLogs.INSERT_TRIGGERED, CLASS_NAME), MessageType.LOG,
       this.#logLevel);
     return this.#skyflowContainer.insert(records, options);
   }
 
-  detokenize(detokenizeInput: IDetokenizeInput): Promise<IRevealResponseType> {
+  detokenize(detokenizeInput: IDetokenizeInput): Promise<DetokenizeResponse> {
     printLog(parameterizedString(logs.infoLogs.DETOKENIZE_TRIGGERED, CLASS_NAME),
       MessageType.LOG, this.#logLevel);
     return this.#skyflowContainer.detokenize(detokenizeInput);
   }
 
-  getById(getByIdInput: IGetByIdInput) {
+  getById(getByIdInput: IGetByIdInput): Promise<GetByIdResponse> {
     printLog(logs.warnLogs.GET_BY_ID_DEPRECATED, MessageType.WARN, this.#logLevel);
     printLog(parameterizedString(logs.infoLogs.GET_BY_ID_TRIGGERED, CLASS_NAME),
       MessageType.LOG, this.#logLevel);
     return this.#skyflowContainer.getById(getByIdInput);
   }
 
-  get(getInput: IGetInput, options?: IGetOptions) {
+  get(getInput: IGetInput, options?: IGetOptions): Promise<GetResponse> {
     printLog(parameterizedString(logs.infoLogs.GET_TRIGGERED, CLASS_NAME),
       MessageType.LOG, this.#logLevel);
     return this.#skyflowContainer.get(getInput, options);
   }
 
-  delete(records: IDeleteRecordInput, options?: IDeleteOptions) {
+  delete(records: IDeleteRecordInput, options?: IDeleteOptions): Promise<DeleteResponse> {
     printLog(parameterizedString(logs.infoLogs.DELETE_TRIGGERED, CLASS_NAME), MessageType.LOG,
       this.#logLevel);
     return this.#skyflowContainer.delete(records, options);

--- a/src/utils/common/index.ts
+++ b/src/utils/common/index.ts
@@ -1,3 +1,6 @@
+import { IUpsertOptions } from '../../core-utils/collect';
+import { CardType, ElementType } from '../../core/constants';
+
 /*
 Copyright (c) 2022 Skyflow, Inc.
 */
@@ -147,7 +150,7 @@ export interface IDeleteRecord {
 export interface IDeleteOptions {}
 
 export interface IDeleteRecordInput {
-  options?: IDeleteOptions;
+  // options?: IDeleteOptions;
   records: IDeleteRecord[];
 }
 
@@ -181,4 +184,124 @@ export interface MeticsObjectType {
 
 export interface SharedMeticsObjectType {
   records: MeticsObjectType[];
+}
+
+export interface InsertResponse {
+  records?: InsertResponseRecords[],
+  errors?: ErrorRecord[];
+}
+
+export interface CollectResponse extends InsertResponse {}
+export interface DetokenizeResponse extends IRevealResponseType {}
+
+export interface InsertResponseRecords {
+  fields: Record<string, any>,
+  table: string;
+}
+
+export interface ErrorRecord {
+  code: number,
+  description: string;
+}
+
+export interface GetByIdResponse {
+  records?: GetByIdResponseRecord[],
+  errors?: ErrorRecord[];
+}
+
+export interface GetByIdResponseRecord {
+  fields: Record<string, any>,
+  table: string;
+}
+
+export interface GetResponse {
+  records?: GetResponseRecord[],
+  errors?: ErrorRecord[];
+}
+
+export interface GetResponseRecord {
+  fields: Record<string, any>,
+  table: string;
+}
+
+export interface DeleteResponse {
+  records?: DeleteResponseRecord[],
+  errors?: DeleteErrorRecords[];
+}
+export interface DeleteResponseRecord {
+  skyflow_id: string,
+  deleted: boolean;
+}
+
+export interface DeleteErrorRecords {
+  id: string,
+  error: ErrorRecord;
+}
+
+export interface ContainerOptions {
+  layout: number[],
+  styles?: InputStyles, // check implementation below
+  errorTextStyles?: ErrorTextStyles, // check implementation below
+}
+
+export interface ErrorTextStyles {
+  base?: object,
+  global?: object;
+}
+
+export interface LabelStyles extends ErrorTextStyles {
+  focus?: object,
+  requiredAsterisk?: object;
+}
+
+export interface InputStyles extends ErrorTextStyles {
+  focus?: object,
+  complete?: object,
+  empty?: object,
+  invalid?: object,
+  cardIcon?: object,
+  copyIcon?: object
+}
+
+export interface CollectElementOptions {
+  required: boolean,
+  format?: string,
+  translation?: Record<string, string>,
+  enableCardIcon?: boolean,
+  enableCopy?: boolean,
+  cardMetadata?: CardMetadata,
+  preserveFileName?: boolean,
+  allowedFileType?: string[],
+  blockEmptyFiles?: boolean,
+  masking?: boolean,
+  maskingChar?: string,
+}
+
+export interface CardMetadata {
+  scheme: CardType[]
+}
+
+export interface CollectElementInput {
+  table?: string;
+  column?: string;
+  label?: string;
+  inputStyles?: InputStyles;
+  labelStyles?: LabelStyles;
+  errorTextStyles?: ErrorTextStyles;
+  placeholder?: string;
+  type: ElementType;
+  altText?: string;
+  validations?: IValidationRule[]
+  skyflowID?: string;
+}
+
+export interface ICollectOptions {
+  tokens?: boolean;
+  additionalFields?: IInsertRecordInput;
+  upsert?: Array<IUpsertOptions>
+}
+
+export interface UploadFilesResponse {
+  fileUploadResponse: [skyflow_id: string],
+  errorResponse: [error: ErrorRecord]
 }

--- a/src/utils/common/index.ts
+++ b/src/utils/common/index.ts
@@ -245,22 +245,22 @@ export interface ContainerOptions {
 }
 
 export interface ErrorTextStyles {
-  base?: object,
-  global?: object;
+  base?: Record<string, string>,
+  global?: Record<string, string>;
 }
 
 export interface LabelStyles extends ErrorTextStyles {
-  focus?: object,
-  requiredAsterisk?: object;
+  focus?: Record<string, string>,
+  requiredAsterisk?: Record<string, string>;
 }
 
 export interface InputStyles extends ErrorTextStyles {
-  focus?: object,
-  complete?: object,
-  empty?: object,
-  invalid?: object,
-  cardIcon?: object,
-  copyIcon?: object
+  focus?: Record<string, string>,
+  complete?: Record<string, string>,
+  empty?: Record<string, string>,
+  invalid?: Record<string, string>,
+  cardIcon?: Record<string, string>,
+  copyIcon?: Record<string, string>
 }
 
 export interface CollectElementOptions {

--- a/src/utils/validators/index.ts
+++ b/src/utils/validators/index.ts
@@ -9,7 +9,6 @@ import {
   DEFAULT_CARD_LENGTH_RANGE,
   ElementType,
 } from '../../core/constants';
-import { CollectElementInput } from '../../core/external/collect/collect-container';
 import { IRevealElementInput } from '../../core/external/reveal/reveal-container';
 import SkyflowError from '../../libs/skyflow-error';
 import { ISkyflow } from '../../skyflow';
@@ -22,6 +21,7 @@ import {
   IGetByIdInput,
   IDeleteRecordInput,
   IGetOptions,
+  CollectElementInput,
 } from '../common';
 import SKYFLOW_ERROR_CODE from '../constants';
 import { appendZeroToOne } from '../helpers';


### PR DESCRIPTION
This PR add typescript public interfaces and consolidates all imports to a single source.

## Why
- The JS SDK had very little support for typescript.
- The import statement were spread out which showed very nested paths.

## Goal
- Fix gaps in typescript public interfaces in JS SDK.
- Consolidate various imports across SDK and export from a single source.

## Testing
- Tested the changes manually