### PR TITLE
SK-2105 Add Samples for typescript support 

### DIFF
--- a/samples/using-typescript/3ds-helper-functions/package.json
+++ b/samples/using-typescript/3ds-helper-functions/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "3dshelperfunctions",
+  "version": "1.0.0",
+  "description": "A Sample on how to add event listeners on Collect Elements ",
+  "main": "index.js",
+  "scripts": {
+    "start": "parcel src/index.html --open",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "license": "ISC",
+  "dependencies": {
+    "skyflow-js": "^2.3.1"
+  },
+  "devDependencies": {
+    "parcel": "^2.0.1"
+  }
+}

--- a/samples/using-typescript/3ds-helper-functions/src/index.html
+++ b/samples/using-typescript/3ds-helper-functions/src/index.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>3DS Helper functions</title>
+
+    <style>
+      body {
+        display: flex;
+        flex-direction: column;
+      }
+      .empty-div {
+        height: 100px;
+        width: 350px;
+      }
+      .reveal-view {
+        margin-top: 48px;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="actionButtons">
+      <h3>3DS Browser Details</h3>
+      <!-- COllect Part -->
+      <div>
+        <button id="getBrowserDetails">Generate 3DS Browser Details</button>
+        <button id="redirectToChallenge">Redirect To Challenge</button>
+      </div>
+      <div></div>
+      <pre id="threeDSBrowserDetails"></pre>
+    </div>
+    <div id="challengeWindow"></div>
+    <script type="module" src="index.js"></script>
+  </body>
+</html>

--- a/samples/using-typescript/3ds-helper-functions/src/index.ts
+++ b/samples/using-typescript/3ds-helper-functions/src/index.ts
@@ -1,0 +1,47 @@
+
+/*
+  Copyright (c) 2025 Skyflow, Inc.
+*/
+
+import Skyflow from 'skyflow-js';
+
+try {
+  const actionButtons = document.getElementById("actionButtons") as HTMLElement;
+  const getDetailsButton = document.getElementById("getBrowserDetails") as HTMLElement;
+  
+  if (getDetailsButton) {
+    getDetailsButton.addEventListener("click", () => {
+      const browserDetails = Skyflow.ThreeDS.getBrowserDetails();
+      const detailsElement = document.getElementById("threeDSBrowserDetails");
+      if (detailsElement) {
+        detailsElement.innerHTML = JSON.stringify(browserDetails);
+      }
+    });
+
+    const redirectButton = document.getElementById("redirectToChallenge");
+    if (redirectButton) {
+      redirectButton.addEventListener("click", () => {
+        const challengeWindow = document.getElementById("challengeWindow") as HTMLElement;
+        const challengeIFrame = Skyflow.ThreeDS.showChallenge(
+          "<acs-url>",
+          "<c-req>",
+          "04",
+          challengeWindow
+        );
+
+        challengeIFrame.addEventListener("load", function () {
+          if (actionButtons.hidden) {
+            challengeIFrame.hidden = true;
+            actionButtons.hidden = false;
+          } else {
+            actionButtons.hidden = true;
+          }
+        });
+      });
+    }
+  }
+} catch (err) {
+  if (err instanceof Error) {
+    console.error(err.message);
+  }
+}

--- a/samples/using-typescript/3ds-helper-functions/src/index.ts
+++ b/samples/using-typescript/3ds-helper-functions/src/index.ts
@@ -3,7 +3,7 @@
   Copyright (c) 2025 Skyflow, Inc.
 */
 
-import Skyflow from 'skyflow-js';
+import Skyflow, { ThreeDSBrowserDetails } from 'skyflow-js';
 
 try {
   const actionButtons = document.getElementById("actionButtons") as HTMLElement;
@@ -11,7 +11,7 @@ try {
   
   if (getDetailsButton) {
     getDetailsButton.addEventListener("click", () => {
-      const browserDetails = Skyflow.ThreeDS.getBrowserDetails();
+      const browserDetails: ThreeDSBrowserDetails = Skyflow.ThreeDS.getBrowserDetails();
       const detailsElement = document.getElementById("threeDSBrowserDetails");
       if (detailsElement) {
         detailsElement.innerHTML = JSON.stringify(browserDetails);

--- a/samples/using-typescript/README.md
+++ b/samples/using-typescript/README.md
@@ -1,0 +1,10 @@
+### Running the Samples
+
+install the dependencies
+```
+$ npm install
+```
+run the sample 
+```
+$ npm start
+```

--- a/samples/using-typescript/collect-element-listeners/package.json
+++ b/samples/using-typescript/collect-element-listeners/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "collectelementlisteners",
+  "version": "1.0.0",
+  "description": "A Sample on how to add event listeners on Collect Elements ",
+  "main": "index.js",
+  "scripts": {
+    "start": "parcel src/index.html --open",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "license": "ISC",
+  "dependencies": {
+    "skyflow-js": "^2.3.1"
+  },
+  "devDependencies": {
+    "parcel": "^2.0.1"
+  }
+}

--- a/samples/using-typescript/collect-element-listeners/src/index.html
+++ b/samples/using-typescript/collect-element-listeners/src/index.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Collect Element Listeners</title>
+
+    <style>
+      body {
+        display: flex;
+        flex-direction: column;
+      }
+      .empty-div {
+        height: 100px;
+        width: 350px;
+      }
+      .reveal-view {
+        margin-top: 48px;
+      }
+    </style>
+  </head>
+  <body>
+    <h3>Collect Elements</h3>
+    <!-- COllect Part -->
+    <div>
+      <div id="collectCardNumber" class="empty-div"></div>
+      <div id="collectCvv" class="empty-div"></div>
+      <div id="collectExpiryDate" class="empty-div"></div>
+      <div id="collectCardholderName" class="empty-div"></div>
+      <div>
+        <button id="collectPCIData">Collect PCI Data</button>
+      </div>
+      <div>
+        <pre id="collectResponse"></pre>
+      </div>
+    </div>
+
+    <script type="module" src="index.js"></script>
+  </body>
+</html>

--- a/samples/using-typescript/collect-element-listeners/src/index.ts
+++ b/samples/using-typescript/collect-element-listeners/src/index.ts
@@ -1,0 +1,159 @@
+/*
+  Copyright (c) 2025 Skyflow, Inc.
+*/
+
+import Skyflow, { 
+  CollectContainer,
+  CollectElement, 
+  CollectResponse,
+} from 'skyflow-js';
+
+try {
+  const skyflow = Skyflow.init({
+    vaultID: '<VAULT_ID>',
+    vaultURL: '<VAULT_URL>',
+    getBearerToken: () => {
+      return new Promise((resolve, reject) => {
+        const Http = new XMLHttpRequest();
+
+        Http.onreadystatechange = () => {
+          if (Http.readyState === 4 && Http.status === 200) {
+            const response = JSON.parse(Http.responseText);
+            resolve(response.accessToken);
+          }
+        };
+        const url = '<TOKEN_END_POINT_URL>';
+        Http.open('GET', url);
+        Http.send();
+      });
+    },
+    options: {
+      logLevel: Skyflow.LogLevel.ERROR,
+      // Actual value of element can only be accessed inside the handler, 
+      // when the env is set to DEV.
+      // Make sure the env is set to PROD when using skyflow-js in production
+      env: Skyflow.Env.DEV,
+    }
+  });
+
+  // Create collect Container
+  const collectContainer = skyflow.container(Skyflow.ContainerType.COLLECT) as CollectContainer;
+
+  // Custom styles for collect elements
+  const collectStylesOptions = {
+    inputStyles: {
+      base: {
+        border: '1px solid #eae8ee',
+        padding: '10px 16px',
+        borderRadius: '4px',
+        color: '#1d1d1d',
+        marginTop: '4px',
+      },
+      complete: {
+        color: '#4caf50',
+      },
+      empty: {},
+      focus: {},
+      invalid: {
+        color: '#f44336',
+      },
+    },
+    labelStyles: {
+      base: {
+        fontSize: '16px',
+        fontWeight: 'bold',
+      },
+    },
+    errorTextStyles: {
+      base: {
+        color: '#f44336',
+      },
+    },
+  };
+
+  
+  // Create collect elements
+  const cardNumberElement: CollectElement = collectContainer.create({
+    table: 'pii_fields',
+    column: 'primary_card.card_number',
+    ...collectStylesOptions,
+    placeholder: 'card number',
+    label: 'Card Number',
+    type: Skyflow.ElementType.CARD_NUMBER,
+  });
+
+  const cvvElement: CollectElement = collectContainer.create({
+    table: 'pii_fields',
+    column: 'primary_card.cvv',
+    ...collectStylesOptions,
+    label: 'Cvv',
+    placeholder: 'cvv',
+    type: Skyflow.ElementType.CVV,
+  });
+
+  const expiryDateElement: CollectElement = collectContainer.create({
+    table: 'pii_fields',
+    column: 'expiry_date',
+    ...collectStylesOptions,
+    label: 'Expiry Date',
+    placeholder: 'MM/YYYY',
+    type: Skyflow.ElementType.EXPIRATION_DATE,
+  });
+
+  const cardHolderNameElement: CollectElement = collectContainer.create({
+    table: 'pii_fields',
+    column: 'first_name',
+    ...collectStylesOptions,
+    label: 'Card Holder Name',
+    placeholder: 'cardholder name',
+    type: Skyflow.ElementType.CARDHOLDER_NAME,
+  });
+
+  // Mount the elements.
+  cardNumberElement.mount('#collectCardNumber');
+  cvvElement.mount('#collectCvv');
+  expiryDateElement.mount('#collectExpiryDate');
+  cardHolderNameElement.mount('#collectCardholderName');
+
+  // Add listeners to Collect Elements.
+
+  // Add READY EVENT Listener.
+  cardNumberElement.on(Skyflow.EventName.READY, (readyState) => {
+    console.log('Ready Event Triggered', readyState);
+  });
+
+  // Add CHANGE EVENT Listener.
+  cvvElement.on(Skyflow.EventName.CHANGE, (changeState: any) => {
+    console.log('CHANGE Event Triggered', changeState);
+  });
+
+  // Add FOCUS EVENT Listener.
+  expiryDateElement.on(Skyflow.EventName.FOCUS, (focusState: any) => {
+    console.log('FOCUS Event Triggered', focusState);
+  });
+
+  // Add BLUR EVENT Listener.
+  cardHolderNameElement.on(Skyflow.EventName.BLUR, (blurState: any) => {
+    console.log('BLUR Event Triggered', blurState);
+  });
+
+  // Collect all elements data.
+  const collectButton = document.getElementById('collectPCIData');
+  if (collectButton) {
+    collectButton.addEventListener('click', () => {
+      const collectResponse: Promise<CollectResponse> = collectContainer.collect();
+      collectResponse
+        .then((response) => {
+          const responseElement = document.getElementById('collectResponse');
+          if (responseElement) {
+            responseElement.innerHTML = JSON.stringify(response, null, 2);
+          }
+        })
+        .catch((err: Error) => {
+          console.error(err);
+        });
+    });
+  }
+} catch (err: unknown) {
+  console.error(err);
+}

--- a/samples/using-typescript/collect-element-listeners/src/index.ts
+++ b/samples/using-typescript/collect-element-listeners/src/index.ts
@@ -6,16 +6,19 @@ import Skyflow, {
   CollectContainer,
   CollectElement, 
   CollectResponse,
+  ErrorTextStyles,
+  InputStyles,
+  ISkyflow,
+  LabelStyles,
 } from 'skyflow-js';
 
 try {
-  const skyflow = Skyflow.init({
+  const config: ISkyflow = {
     vaultID: '<VAULT_ID>',
     vaultURL: '<VAULT_URL>',
     getBearerToken: () => {
       return new Promise((resolve, reject) => {
         const Http = new XMLHttpRequest();
-
         Http.onreadystatechange = () => {
           if (Http.readyState === 4 && Http.status === 200) {
             const response = JSON.parse(Http.responseText);
@@ -34,49 +37,49 @@ try {
       // Make sure the env is set to PROD when using skyflow-js in production
       env: Skyflow.Env.DEV,
     }
-  });
+  }
+  const skyflow: Skyflow = Skyflow.init(config);
 
   // Create collect Container
   const collectContainer = skyflow.container(Skyflow.ContainerType.COLLECT) as CollectContainer;
 
   // Custom styles for collect elements
-  const collectStylesOptions = {
-    inputStyles: {
-      base: {
-        border: '1px solid #eae8ee',
-        padding: '10px 16px',
-        borderRadius: '4px',
-        color: '#1d1d1d',
-        marginTop: '4px',
-      },
-      complete: {
-        color: '#4caf50',
-      },
-      empty: {},
-      focus: {},
-      invalid: {
-        color: '#f44336',
-      },
+  const inputStyles: InputStyles = {
+    base: {
+      border: '1px solid #eae8ee',
+      padding: '10px 16px',
+      borderRadius: '4px',
+      color: '#1d1d1d',
+      marginTop: '4px',
     },
-    labelStyles: {
-      base: {
-        fontSize: '16px',
-        fontWeight: 'bold',
-      },
+    complete: {
+      color: '#4caf50',
     },
-    errorTextStyles: {
-      base: {
-        color: '#f44336',
-      },
+    empty: {},
+    focus: {},
+    invalid: {
+      color: '#f44336',
     },
-  };
-
+  }
+  const labelStyles: LabelStyles = {
+    base: {
+      fontSize: '16px',
+      fontWeight: 'bold',
+    },
+  }
+  const errorTextStyles: ErrorTextStyles = {
+    base: {
+      color: '#f44336',
+    },
+  }
   
   // Create collect elements
   const cardNumberElement: CollectElement = collectContainer.create({
     table: 'pii_fields',
     column: 'primary_card.card_number',
-    ...collectStylesOptions,
+    inputStyles: inputStyles,
+    labelStyles: labelStyles,
+    errorTextStyles: errorTextStyles,
     placeholder: 'card number',
     label: 'Card Number',
     type: Skyflow.ElementType.CARD_NUMBER,
@@ -85,7 +88,9 @@ try {
   const cvvElement: CollectElement = collectContainer.create({
     table: 'pii_fields',
     column: 'primary_card.cvv',
-    ...collectStylesOptions,
+    inputStyles: inputStyles,
+    labelStyles: labelStyles,
+    errorTextStyles: errorTextStyles,
     label: 'Cvv',
     placeholder: 'cvv',
     type: Skyflow.ElementType.CVV,
@@ -94,7 +99,9 @@ try {
   const expiryDateElement: CollectElement = collectContainer.create({
     table: 'pii_fields',
     column: 'expiry_date',
-    ...collectStylesOptions,
+    inputStyles: inputStyles,
+    labelStyles: labelStyles,
+    errorTextStyles: errorTextStyles,
     label: 'Expiry Date',
     placeholder: 'MM/YYYY',
     type: Skyflow.ElementType.EXPIRATION_DATE,
@@ -103,7 +110,9 @@ try {
   const cardHolderNameElement: CollectElement = collectContainer.create({
     table: 'pii_fields',
     column: 'first_name',
-    ...collectStylesOptions,
+    inputStyles: inputStyles,
+    labelStyles: labelStyles,
+    errorTextStyles: errorTextStyles,
     label: 'Card Holder Name',
     placeholder: 'cardholder name',
     type: Skyflow.ElementType.CARDHOLDER_NAME,
@@ -118,7 +127,7 @@ try {
   // Add listeners to Collect Elements.
 
   // Add READY EVENT Listener.
-  cardNumberElement.on(Skyflow.EventName.READY, (readyState) => {
+  cardNumberElement.on(Skyflow.EventName.READY, (readyState: any) => {
     console.log('Ready Event Triggered', readyState);
   });
 
@@ -143,13 +152,13 @@ try {
     collectButton.addEventListener('click', () => {
       const collectResponse: Promise<CollectResponse> = collectContainer.collect();
       collectResponse
-        .then((response) => {
+        .then((response: CollectResponse) => {
           const responseElement = document.getElementById('collectResponse');
           if (responseElement) {
             responseElement.innerHTML = JSON.stringify(response, null, 2);
           }
         })
-        .catch((err: Error) => {
+        .catch((err: CollectResponse) => {
           console.error(err);
         });
     });

--- a/samples/using-typescript/composable-elements-update/package.json
+++ b/samples/using-typescript/composable-elements-update/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "composable-elements-update",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "start": "parcel src/index.html --open",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "skyflow-js": "^2.3.1"
+  },
+  "devDependencies": {
+    "parcel": "^2.8.3"
+  }
+}

--- a/samples/using-typescript/composable-elements-update/src/index.html
+++ b/samples/using-typescript/composable-elements-update/src/index.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Skyflow Elements</title>
+    <script src="https://js.skyflow.com/v1/index.js"></script>
+    <style>
+        body {
+            display: flex;
+            flex-direction: column;
+        }
+
+        .empty-div {
+            height: 200px;
+            width: 100%;
+        }
+
+        .reveal-view {
+            margin-top: 48px;
+        }
+    </style>
+</head>
+
+<body>
+    <h3>Composable Elements</h3>
+    <div>
+        <div>
+            <div id="composableContainer" class="empty-div"></div>
+            <button id="collectPCIData">Collect PCI Data</button>
+            <button id="updateElements">Update Elements Properties</button>
+        </div>
+
+        <div>
+            <pre id="collectResponse"></pre>
+        </div>
+    </div>
+    <!-- Reveal Part-->
+    <div id="revealView" class="reveal-view">
+        <h3>Reveal Elements</h3>
+        <div id="revealCardNumber" class="empty-div"></div>
+        <div id="revealCvv" class="empty-div"></div>
+        <div id="revealExpiryDate" class="empty-div"></div>
+        <div id="revealCardholderName" class="empty-div"></div>
+        <div>
+            <button id="revealPCIData">Reveal PCI Data</button>
+        </div>
+    </div>
+
+    <script type="module" src="index.js"></script>
+</body>
+
+</html>

--- a/samples/using-typescript/composable-elements-update/src/index.ts
+++ b/samples/using-typescript/composable-elements-update/src/index.ts
@@ -1,0 +1,346 @@
+/*
+	Copyright (c) 2025 Skyflow, Inc.
+*/
+
+import Skyflow, {
+    ComposableContainer,
+    ComposableElement,
+    CollectResponse,
+    ContainerOptions,
+    RevealContainer,
+    RevealElement,
+    RevealResponse,
+} from 'skyflow-js';
+
+try {
+    const revealView = document.getElementById('revealView');
+    if (revealView) {
+        revealView.style.visibility = 'hidden';
+    }
+    const skyflow = Skyflow.init({
+        vaultID: '<VAULT_ID>',
+        vaultURL: '<VAULT_URL>',
+        getBearerToken: () => {
+            return new Promise((resolve, reject) => {
+                const Http = new XMLHttpRequest();
+
+                Http.onreadystatechange = () => {
+                    if (Http.readyState === 4 && Http.status === 200) {
+                        const response = JSON.parse(Http.responseText);
+                        resolve(response.accessToken);
+                    }
+                };
+                const url = '<TOKEN_END_POINT_URL>';
+                Http.open('GET', url);
+                Http.send();
+            });
+        },
+        options: {
+            logLevel: Skyflow.LogLevel.ERROR,
+            env: Skyflow.Env.PROD,
+        },
+    });
+
+    //custom styles for collect elements
+    const cardholderStyles = {
+        inputStyles: {
+            base: {
+                fontFamily: 'Inter',
+                fontStyle: 'normal',
+                fontWeight: 400,
+                fontSize: '14px',
+                lineHeight: '21px',
+                width: '294px'
+            },
+        },
+        labelStyles: {
+        },
+        errorTextStyles: {
+        },
+    };
+
+    const cardNumberStyles = {
+        inputStyles: {
+            base: {
+                fontFamily: 'Inter',
+                fontStyle: 'normal',
+                fontWeight: 400,
+                fontSize: '14px',
+                lineHeight: '21px',
+                width: '294px',
+                paddingLeft: '18px'
+            },
+        },
+        labelStyles: {
+        },
+        errorTextStyles: {
+        },
+    };
+
+    const expiryDateStyles = {
+        inputStyles: {
+            base: {
+                fontFamily: 'Inter',
+                fontStyle: 'normal',
+                fontWeight: 400,
+                fontSize: '14px',
+                lineHeight: '21px',
+                width: '49px'
+            },
+        },
+        labelStyles: {
+        },
+        errorTextStyles: {
+        },
+    };
+
+    const cvvStyles = {
+        inputStyles: {
+            base: {
+                fontFamily: 'Inter',
+                fontStyle: 'normal',
+                fontWeight: 400,
+                fontSize: '14px',
+                lineHeight: '21px',
+                width: '30px'
+            },
+        },
+        labelStyles: {
+        },
+        errorTextStyles: {
+            base: {
+                color: 'red'
+            }
+        },
+    };
+
+    const containerOptions: ContainerOptions = {
+        layout: [1, 3],
+        styles: {
+            base: {
+                border: '1px solid #eae8ee',
+                padding: '10px 16px',
+                borderRadius: '4px',
+                margin: '12px 2px',
+                boxShadow: '8px'
+            }
+        },
+        errorTextStyles: {
+            base: {
+                color: 'red'
+            }
+        }
+    }
+    // create collect Container
+    const composableContainer = skyflow.container(Skyflow.ContainerType.COMPOSABLE, containerOptions) as ComposableContainer;
+
+    const cardHolderNameElement: ComposableElement = composableContainer.create({
+        table: 'pii_fields',
+        column: 'first_name',
+        ...cardholderStyles,
+        label: 'Cardholder Name',
+        placeholder: 'cardholder name',
+        type: Skyflow.ElementType.CARDHOLDER_NAME,
+    });
+
+    const cardNumberElement: ComposableElement = composableContainer.create({
+        table: 'pii_fields',
+        column: 'primary_card.card_number',
+        ...cardNumberStyles,
+        type: Skyflow.ElementType.CARD_NUMBER,
+        placeholder: 'XXXX XXXX XXXX XXXX'
+    });
+
+    const expiryDateElement: ComposableElement = composableContainer.create({
+        table: 'cards',
+        column: 'expiry_date',
+        ...expiryDateStyles,
+        placeholder: 'MM/YY',
+        type: Skyflow.ElementType.EXPIRATION_DATE,
+    });
+
+
+    const cvvElement: ComposableElement = composableContainer.create({
+        table: 'pii_fields',
+        column: 'primary_card.cvv',
+        ...cvvStyles,
+        placeholder: 'CVC',
+        type: Skyflow.ElementType.CVV,
+    });
+
+    // mount the container
+    composableContainer.mount('#composableContainer');
+
+    // Add OnSubmit event listner on composable container
+    composableContainer.on(Skyflow.EventName.SUBMIT, () => {
+        // Handle when enter key pressed in any container elements
+        console.log('Submit Listener is being Triggered.');
+    });
+
+
+    // Sample helper function to determine cvv length. 
+    const findCvvLength = (cardBinValue: string): number => {
+        console.log('Came here..!');
+        const amexRegex = /^3[47][0-9]{4}$/
+        return amexRegex.test(cardBinValue.slice(0, 6)) ? 4 : 3
+    };
+
+    // Validation rules for cvv element.
+    const length3Rule = {
+        type: Skyflow.ValidationRuleType.LENGTH_MATCH_RULE,
+        params: {
+            max: 3,
+            error: 'cvv must be 3 digits',
+        },
+    };
+
+    const length4Rule = {
+        type: Skyflow.ValidationRuleType.LENGTH_MATCH_RULE,
+        params: {
+            min: 4,
+            error: 'cvv must be 4 digits',
+        },
+    };
+
+    // OnChange listener for cardNumber element.
+    cardNumberElement.on(Skyflow.EventName.CHANGE, (state: any) => {
+        console.log('update validation', state)
+        if (state.isValid && state.value) {
+            // update cvv element validation rule.
+            if (findCvvLength(state.value) === 3) {
+                cvvElement.update({ validations: [length3Rule] });
+            }
+            else
+                cvvElement.update({ validations: [length4Rule] });
+        }
+    });
+
+    // update composable elements
+    const updateElementsButton = document.getElementById('updateElements');
+    if (updateElementsButton) {
+        updateElementsButton.addEventListener('click', () => {
+            
+            // update label,placeholder on cardholderName,
+            cardHolderNameElement.update({
+                label: 'CARDHOLDER NAME',
+                placeholder: 'Eg: John'
+            });
+
+            // update styles on card number
+            cardNumberElement.update({
+                inputStyles: {
+                    base: {
+                        color: 'blue'
+                    }
+                }
+            });
+
+            // update table,coloumn on expiry date
+            expiryDateElement.update({
+                table: 'pii_fields',
+                column: 'primary_card.expiry_date',
+            });
+
+        });
+    }
+
+    // collect all elements data
+    const collectButton = document.getElementById('collectPCIData');
+    if (collectButton) {
+        collectButton.addEventListener('click', () => {
+            const collectResponse: Promise<CollectResponse> = composableContainer.collect();
+            collectResponse
+                .then(response => {
+                    console.log(response);
+                    response = response;
+                    const responseElement = document.getElementById('collectResponse');
+                    if (responseElement) {
+                        responseElement.innerHTML = JSON.stringify(response, null, 2);
+                    }
+
+                    if (revealView) {
+                        revealView.style.visibility = 'visible';
+                    }
+
+                    const revealStyleOptions = {
+                        inputStyles: {
+                            base: {
+                                border: '1px solid #eae8ee',
+                                padding: '10px 16px',
+                                borderRadius: '4px',
+                                color: '#1d1d1d',
+                                marginTop: '4px',
+                            },
+                        },
+                        labelStyles: {
+                            base: {
+                                fontSize: '16px',
+                                fontWeight: 'bold',
+                            },
+                        },
+                        errorTextStyles: {
+                            base: {
+                                color: '#f44336',
+                            },
+                        },
+                    };
+
+                    // Create Reveal Elements With Tokens.
+                    const fieldsTokenData = response.records[0].fields;
+                    const revealContainer = skyflow.container(
+                        Skyflow.ContainerType.REVEAL
+                    ) as RevealContainer;
+                    const revealCardNumberElement: RevealElement = revealContainer.create({
+                        token: fieldsTokenData.primary_card.card_number,
+                        label: 'Card Number',
+                        ...revealStyleOptions,
+
+                    });
+                    revealCardNumberElement.mount('#revealCardNumber');
+
+                    const revealCardCvvElement: RevealElement = revealContainer.create({
+                        token: fieldsTokenData.primary_card.cvv,
+                        label: 'Cvv',
+                        ...revealStyleOptions,
+
+                    });
+                    revealCardCvvElement.mount('#revealCvv');
+
+                    const revealCardExpiryElement: RevealElement = revealContainer.create({
+                        token: fieldsTokenData.primary_card.expiry_date,
+                        label: 'Card Expiry Date',
+                        ...revealStyleOptions,
+                    });
+                    revealCardExpiryElement.mount('#revealExpiryDate');
+
+                    const revealCardholderNameElement: RevealElement = revealContainer.create({
+                        token: fieldsTokenData.first_name,
+                        label: 'Card Holder Name',
+                        ...revealStyleOptions,
+                    });
+                    revealCardholderNameElement.mount('#revealCardholderName');
+
+                    const revealButton = document.getElementById('revealPCIData');
+
+                    if (revealButton) {
+                        revealButton.addEventListener('click', () => {
+                            const revealResonse: Promise<RevealResponse> = revealContainer.reveal();
+                            revealResonse.then(res => {
+                                console.log(res);
+                            })
+                            .catch(err => {
+                                console.log(err);
+                            });
+                        });
+                    }
+                })
+                .catch(err => {
+                    console.log(err);
+                });
+        });
+    }
+
+
+} catch (err: unknown) {
+    console.error(err);
+}

--- a/samples/using-typescript/composable-elements-update/src/index.ts
+++ b/samples/using-typescript/composable-elements-update/src/index.ts
@@ -11,6 +11,7 @@ import Skyflow, {
     ErrorTextStyles,
     ISkyflow,
     InputStyles,
+    IRevealElementInput,
     IValidationRule,
     LabelStyles,
     RevealContainer,
@@ -46,7 +47,7 @@ try {
 			env: Skyflow.Env.PROD,
 		},
 	}
-	const skyflow = Skyflow.init(config);
+	const skyflow: Skyflow = Skyflow.init(config);
 
     //custom styles for collect elements
     const cardholderStyles = {
@@ -131,12 +132,12 @@ try {
                 margin: '12px 2px',
                 boxShadow: '8px'
             }
-        },
+        } as InputStyles,
         errorTextStyles: {
             base: {
                 color: 'red'
             }
-        }
+        } as ErrorTextStyles,
     }
     // create collect Container
     const composableContainer = skyflow.container(Skyflow.ContainerType.COMPOSABLE, containerOptions) as ComposableContainer;
@@ -302,32 +303,36 @@ try {
                     const revealContainer = skyflow.container(
                         Skyflow.ContainerType.REVEAL
                     ) as RevealContainer;
-                    const revealCardNumberElement: RevealElement = revealContainer.create({
+                    const revealCardNumberInput: IRevealElementInput = {
                         token: fieldsTokenData.primary_card.card_number,
                         label: 'Card Number',
                         ...revealStyleOptions,
-                    });
+                    };
+                    const revealCardNumberElement: RevealElement = revealContainer.create(revealCardNumberInput);
                     revealCardNumberElement.mount('#revealCardNumber');
 
-                    const revealCardCvvElement: RevealElement = revealContainer.create({
+                    const revealCardCvvInput: IRevealElementInput = {
                         token: fieldsTokenData.primary_card.cvv,
                         label: 'Cvv',
                         ...revealStyleOptions,
-                    });
+                    };
+                    const revealCardCvvElement: RevealElement = revealContainer.create(revealCardCvvInput);
                     revealCardCvvElement.mount('#revealCvv');
 
-                    const revealCardExpiryElement: RevealElement = revealContainer.create({
+                    const revealCardExpiryInput: IRevealElementInput = {
                         token: fieldsTokenData.primary_card.expiry_date,
                         label: 'Card Expiry Date',
                         ...revealStyleOptions,
-                    });
+                    };
+                    const revealCardExpiryElement: RevealElement = revealContainer.create(revealCardExpiryInput);
                     revealCardExpiryElement.mount('#revealExpiryDate');
 
-                    const revealCardholderNameElement: RevealElement = revealContainer.create({
+                    const revealCardholderNameInput: IRevealElementInput = {
                         token: fieldsTokenData.first_name,
                         label: 'Card Holder Name',
                         ...revealStyleOptions,
-                    });
+                    };
+                    const revealCardholderNameElement: RevealElement = revealContainer.create(revealCardholderNameInput);
                     revealCardholderNameElement.mount('#revealCardholderName');
 
                     const revealButton = document.getElementById('revealPCIData');

--- a/samples/using-typescript/composable-elements-update/src/index.ts
+++ b/samples/using-typescript/composable-elements-update/src/index.ts
@@ -3,10 +3,16 @@
 */
 
 import Skyflow, {
+    CollectElementInput,
+    CollectResponse,
     ComposableContainer,
     ComposableElement,
-    CollectResponse,
     ContainerOptions,
+    ErrorTextStyles,
+    ISkyflow,
+    InputStyles,
+    IValidationRule,
+    LabelStyles,
     RevealContainer,
     RevealElement,
     RevealResponse,
@@ -17,29 +23,30 @@ try {
     if (revealView) {
         revealView.style.visibility = 'hidden';
     }
-    const skyflow = Skyflow.init({
-        vaultID: '<VAULT_ID>',
-        vaultURL: '<VAULT_URL>',
-        getBearerToken: () => {
-            return new Promise((resolve, reject) => {
-                const Http = new XMLHttpRequest();
+	const config: ISkyflow = {
+		vaultID: '<VAULT_ID>',
+		vaultURL: '<VAULT_URL>',
+		getBearerToken: () => {
+			return new Promise((resolve, reject) => {
+				const Http = new XMLHttpRequest();
 
-                Http.onreadystatechange = () => {
-                    if (Http.readyState === 4 && Http.status === 200) {
-                        const response = JSON.parse(Http.responseText);
-                        resolve(response.accessToken);
-                    }
-                };
-                const url = '<TOKEN_END_POINT_URL>';
-                Http.open('GET', url);
-                Http.send();
-            });
-        },
-        options: {
-            logLevel: Skyflow.LogLevel.ERROR,
-            env: Skyflow.Env.PROD,
-        },
-    });
+				Http.onreadystatechange = () => {
+					if (Http.readyState === 4 && Http.status === 200) {
+						const response = JSON.parse(Http.responseText);
+						resolve(response.accessToken);
+					}
+				};
+				const url = '<TOKEN_END_POINT_URL>';
+				Http.open('GET', url);
+				Http.send();
+			});
+		},
+		options: {
+			logLevel: Skyflow.LogLevel.ERROR,
+			env: Skyflow.Env.PROD,
+		},
+	}
+	const skyflow = Skyflow.init(config);
 
     //custom styles for collect elements
     const cardholderStyles = {
@@ -52,11 +59,11 @@ try {
                 lineHeight: '21px',
                 width: '294px'
             },
-        },
+        } as InputStyles,
         labelStyles: {
-        },
+        } as LabelStyles,
         errorTextStyles: {
-        },
+        } as ErrorTextStyles,
     };
 
     const cardNumberStyles = {
@@ -70,11 +77,11 @@ try {
                 width: '294px',
                 paddingLeft: '18px'
             },
-        },
+        } as InputStyles,
         labelStyles: {
-        },
+        } as LabelStyles,
         errorTextStyles: {
-        },
+        } as ErrorTextStyles,
     };
 
     const expiryDateStyles = {
@@ -87,11 +94,11 @@ try {
                 lineHeight: '21px',
                 width: '49px'
             },
-        },
+        } as InputStyles,
         labelStyles: {
-        },
+        } as LabelStyles,
         errorTextStyles: {
-        },
+        } as ErrorTextStyles,
     };
 
     const cvvStyles = {
@@ -104,14 +111,14 @@ try {
                 lineHeight: '21px',
                 width: '30px'
             },
-        },
+        } as InputStyles,
         labelStyles: {
-        },
+        } as LabelStyles,
         errorTextStyles: {
             base: {
                 color: 'red'
             }
-        },
+        } as ErrorTextStyles,
     };
 
     const containerOptions: ContainerOptions = {
@@ -134,39 +141,42 @@ try {
     // create collect Container
     const composableContainer = skyflow.container(Skyflow.ContainerType.COMPOSABLE, containerOptions) as ComposableContainer;
 
-    const cardHolderNameElement: ComposableElement = composableContainer.create({
+    const cardHolderNameInput: CollectElementInput = {
         table: 'pii_fields',
         column: 'first_name',
         ...cardholderStyles,
         label: 'Cardholder Name',
         placeholder: 'cardholder name',
         type: Skyflow.ElementType.CARDHOLDER_NAME,
-    });
+    }
+    const cardHolderNameElement: ComposableElement = composableContainer.create(cardHolderNameInput);
 
-    const cardNumberElement: ComposableElement = composableContainer.create({
+    const cardNumberInput: CollectElementInput = {
         table: 'pii_fields',
         column: 'primary_card.card_number',
         ...cardNumberStyles,
         type: Skyflow.ElementType.CARD_NUMBER,
         placeholder: 'XXXX XXXX XXXX XXXX'
-    });
+    }
+    const cardNumberElement: ComposableElement = composableContainer.create(cardNumberInput);
 
-    const expiryDateElement: ComposableElement = composableContainer.create({
+    const expiryDateInput: CollectElementInput = {
         table: 'cards',
         column: 'expiry_date',
         ...expiryDateStyles,
         placeholder: 'MM/YY',
         type: Skyflow.ElementType.EXPIRATION_DATE,
-    });
+    }
+    const expiryDateElement: ComposableElement = composableContainer.create(expiryDateInput);
 
-
-    const cvvElement: ComposableElement = composableContainer.create({
+    const cvvInput: CollectElementInput = {
         table: 'pii_fields',
         column: 'primary_card.cvv',
         ...cvvStyles,
         placeholder: 'CVC',
         type: Skyflow.ElementType.CVV,
-    });
+    }
+    const cvvElement: ComposableElement = composableContainer.create(cvvInput);
 
     // mount the container
     composableContainer.mount('#composableContainer');
@@ -186,7 +196,7 @@ try {
     };
 
     // Validation rules for cvv element.
-    const length3Rule = {
+    const length3Rule: IValidationRule = {
         type: Skyflow.ValidationRuleType.LENGTH_MATCH_RULE,
         params: {
             max: 3,
@@ -194,7 +204,7 @@ try {
         },
     };
 
-    const length4Rule = {
+    const length4Rule: IValidationRule = {
         type: Skyflow.ValidationRuleType.LENGTH_MATCH_RULE,
         params: {
             min: 4,
@@ -208,10 +218,13 @@ try {
         if (state.isValid && state.value) {
             // update cvv element validation rule.
             if (findCvvLength(state.value) === 3) {
-                cvvElement.update({ validations: [length3Rule] });
+                const updateOptions: CollectElementInput = { validations: [length3Rule] }
+                cvvElement.update(updateOptions);
             }
-            else
-                cvvElement.update({ validations: [length4Rule] });
+            else {
+                const updateOptions: CollectElementInput = { validations: [length4Rule] }
+                cvvElement.update(updateOptions);
+            }
         }
     });
 
@@ -219,12 +232,11 @@ try {
     const updateElementsButton = document.getElementById('updateElements');
     if (updateElementsButton) {
         updateElementsButton.addEventListener('click', () => {
-            
             // update label,placeholder on cardholderName,
             cardHolderNameElement.update({
                 label: 'CARDHOLDER NAME',
                 placeholder: 'Eg: John'
-            });
+            } as CollectElementInput);
 
             // update styles on card number
             cardNumberElement.update({
@@ -233,13 +245,13 @@ try {
                         color: 'blue'
                     }
                 }
-            });
+            } as CollectElementInput);
 
             // update table,coloumn on expiry date
             expiryDateElement.update({
                 table: 'pii_fields',
                 column: 'primary_card.expiry_date',
-            });
+            } as CollectElementInput);
 
         });
     }
@@ -250,7 +262,7 @@ try {
         collectButton.addEventListener('click', () => {
             const collectResponse: Promise<CollectResponse> = composableContainer.collect();
             collectResponse
-                .then(response => {
+                .then((response: CollectResponse) => {
                     console.log(response);
                     response = response;
                     const responseElement = document.getElementById('collectResponse');
@@ -271,18 +283,18 @@ try {
                                 color: '#1d1d1d',
                                 marginTop: '4px',
                             },
-                        },
+                        } as InputStyles,
                         labelStyles: {
                             base: {
                                 fontSize: '16px',
                                 fontWeight: 'bold',
                             },
-                        },
+                        } as LabelStyles,
                         errorTextStyles: {
                             base: {
                                 color: '#f44336',
                             },
-                        },
+                        } as ErrorTextStyles,
                     };
 
                     // Create Reveal Elements With Tokens.
@@ -294,7 +306,6 @@ try {
                         token: fieldsTokenData.primary_card.card_number,
                         label: 'Card Number',
                         ...revealStyleOptions,
-
                     });
                     revealCardNumberElement.mount('#revealCardNumber');
 
@@ -302,7 +313,6 @@ try {
                         token: fieldsTokenData.primary_card.cvv,
                         label: 'Cvv',
                         ...revealStyleOptions,
-
                     });
                     revealCardCvvElement.mount('#revealCvv');
 
@@ -325,22 +335,20 @@ try {
                     if (revealButton) {
                         revealButton.addEventListener('click', () => {
                             const revealResonse: Promise<RevealResponse> = revealContainer.reveal();
-                            revealResonse.then(res => {
+                            revealResonse.then((res: RevealResponse) => {
                                 console.log(res);
                             })
-                            .catch(err => {
+                            .catch((err: RevealResponse) => {
                                 console.log(err);
                             });
                         });
                     }
                 })
-                .catch(err => {
+                .catch((err: CollectResponse) => {
                     console.log(err);
                 });
         });
     }
-
-
 } catch (err: unknown) {
     console.error(err);
 }

--- a/samples/using-typescript/composable-elements/package.json
+++ b/samples/using-typescript/composable-elements/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "composableelements",
+  "version": "1.0.0",
+  "description": "A Sample on how to add Composable Elements ",
+  "main": "index.js",
+  "scripts": {
+    "start": "parcel src/index.html --open",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "license": "ISC",
+  "dependencies": {
+    "skyflow-js": "^2.3.1"
+  },
+  "devDependencies": {
+    "parcel": "^2.0.1"
+  }
+}

--- a/samples/using-typescript/composable-elements/src/index.html
+++ b/samples/using-typescript/composable-elements/src/index.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+	<meta charset="UTF-8" />
+	<meta http-equiv="X-UA-Compatible" content="IE=edge" />
+	<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+	<title>Skyflow Elements</title>
+	<script src="https://js.skyflow.com/v1/index.js"></script>
+	<style>
+		body {
+			display: flex;
+			flex-direction: column;
+		}
+
+		.empty-div {
+			height: 200px;
+			width: 100%;
+		}
+
+		.reveal-view {
+			margin-top: 48px;
+		}
+	</style>
+</head>
+
+<body>
+	<h3>Composable Elements</h3>
+	<div>
+		<div>
+			<div id="composableContainer" class="empty-div"></div>
+			<button type="submit" id="collectPCIData">Collect PCI Data</button>
+		</div>
+
+		<div>
+			<pre id="collectResponse"></pre>
+		</div>
+	</div>
+	<!-- Reveal Part-->
+	<div id="revealView" class="reveal-view">
+		<h3>Reveal Elements</h3>
+		<div id="revealCardNumber" class="empty-div"></div>
+		<div id="revealCvv" class="empty-div"></div>
+		<div id="revealExpiryDate" class="empty-div"></div>
+		<div id="revealCardholderName" class="empty-div"></div>
+		<div>
+			<button id="revealPCIData">Reveal PCI Data</button>
+		</div>
+	</div>
+	<script type="module" src="index.js"></script>
+</body>
+
+</html>

--- a/samples/using-typescript/composable-elements/src/index.ts
+++ b/samples/using-typescript/composable-elements/src/index.ts
@@ -1,0 +1,269 @@
+/*
+	Copyright (c) 2025 Skyflow, Inc.
+*/
+
+import Skyflow, {
+	ComposableContainer,
+	ComposableElement,
+	CollectResponse,
+	RevealContainer,
+	RevealElement,
+	RevealResponse
+} from 'skyflow-js';
+
+try {
+	const revealView = document.getElementById('revealView');
+	if (revealView) {
+		revealView.style.visibility = 'hidden';
+	}
+	const skyflow = Skyflow.init({
+		vaultID: '<VAULT_ID>',
+		vaultURL: '<VAULT_URL>',
+		getBearerToken: () => {
+			return new Promise((resolve, reject) => {
+				const Http = new XMLHttpRequest();
+
+				Http.onreadystatechange = () => {
+					if (Http.readyState === 4 && Http.status === 200) {
+						const response = JSON.parse(Http.responseText);
+						resolve(response.accessToken);
+					}
+				};
+				const url = '<TOKEN_END_POINT_URL>';
+				Http.open('GET', url);
+				Http.send();
+			});
+		},
+		options: {
+			logLevel: Skyflow.LogLevel.ERROR,
+			env: Skyflow.Env.PROD,
+		},
+	});
+
+	//custom styles for collect elements
+	const cardholderStyles = {
+		inputStyles: {
+			base: {
+				fontFamily: '"Roboto", sans-serif',
+				fontStyle: 'normal',
+				fontWeight: 400,
+				fontSize: '14px',
+				lineHeight: '21px',
+				width: '294px'
+			},
+			global: {
+				'@import' :'url("https://fonts.googleapis.com/css2?family=Roboto&display=swap")',
+			}
+		},
+		labelStyles: {
+		},
+	};
+
+	const cardNumberStyles = {
+		inputStyles: {
+			base: {
+				fontFamily: '"Roboto", sans-serif',
+				fontStyle: 'normal',
+				fontWeight: 400,
+				fontSize: '14px',
+				lineHeight: '21px',
+				width: '294px',
+				paddingLeft: '18px'
+			},
+		},
+		labelStyles: {
+		},
+	};
+
+	const expiryDateStyles = {
+		inputStyles: {
+			base: {
+				fontFamily: '"Roboto", sans-serif',
+				fontStyle: 'normal',
+				fontWeight: 400,
+				fontSize: '14px',
+				lineHeight: '21px',
+				width: '49px'
+			},
+		},
+		labelStyles: {
+		},
+	};
+
+	const cvvStyles = {
+		inputStyles: {
+			base: {
+				fontFamily: '"Roboto", sans-serif',
+				fontStyle: 'normal',
+				fontWeight: 400,
+				fontSize: '14px',
+				lineHeight: '21px',
+				width: '30px'
+			},
+		},
+		labelStyles: {
+		},
+	};
+
+	const containerOptions = {
+		layout: [1, 3],
+		styles: {
+			base: {
+				border: '1px solid #eae8ee',
+				padding: '10px 16px',
+				borderRadius: '4px',
+				margin: '12px 2px',
+				boxShadow: '8px'
+			}
+		},
+		errorTextStyles: {
+			base: {
+				color: 'red',
+				fontFamily: '"Roboto", sans-serif'
+			},
+			global: {
+				'@import' :'url("https://fonts.googleapis.com/css2?family=Roboto&display=swap")',
+			}
+		}
+	}
+	// create collect Container
+	const composableContainer = skyflow.container(Skyflow.ContainerType.COMPOSABLE, containerOptions) as ComposableContainer;
+
+	const cardHolderNameElement: ComposableElement = composableContainer.create({
+		table: 'pii_fields',
+		column: 'first_name',
+		...cardholderStyles,
+		placeholder: 'Cardholder Name',
+		type: Skyflow.ElementType.CARDHOLDER_NAME,
+	});
+
+	const cardNumberElement: ComposableElement = composableContainer.create({
+		table: 'pii_fields',
+		column: 'primary_card.card_number',
+		...cardNumberStyles,
+		type: Skyflow.ElementType.CARD_NUMBER,
+		placeholder: 'XXXX XXXX XXXX XXXX'
+	});
+
+	const expiryDateElement: ComposableElement = composableContainer.create({
+		table: 'pii_fields',
+		column: 'primary_card.expiry_date',
+		...expiryDateStyles,
+		placeholder: 'MM/YY',
+		type: Skyflow.ElementType.EXPIRATION_DATE,
+	});
+
+
+	const cvvElement: ComposableElement = composableContainer.create({
+		table: 'pii_fields',
+		column: 'primary_card.cvv',
+		...cvvStyles,
+		placeholder: 'CVC',
+		type: Skyflow.ElementType.CVV,
+	});
+
+	// mount the container
+	composableContainer.mount('#composableContainer');
+
+	// collect all elements data
+	const collectButton = document.getElementById('collectPCIData');
+	if (collectButton) {
+		collectButton.addEventListener('click', () => {
+			const collectResponse: Promise<CollectResponse> = composableContainer.collect();
+			collectResponse
+				.then(response => {
+					const responseElement = document.getElementById('collectResponse');
+					if (responseElement) {
+						responseElement.innerHTML = JSON.stringify(response, null, 2);
+					}
+
+					if (revealView) {
+						revealView.style.visibility = 'visible';
+					}
+
+					const revealStyleOptions = {
+						inputStyles: {
+							base: {
+								border: '1px solid #eae8ee',
+								padding: '10px 16px',
+								borderRadius: '4px',
+								color: '#1d1d1d',
+								marginTop: '4px',
+								fontFamily: '"Roboto", sans-serif'
+							},
+							global: {
+								'@import' :'url("https://fonts.googleapis.com/css2?family=Roboto&display=swap")',
+							}
+						},
+						labelStyles: {
+							base: {
+								fontSize: '16px',
+								fontWeight: 'bold',
+								fontFamily: '"Roboto", sans-serif'
+							},
+						},
+						errorTextStyles: {
+							base: {
+								color: '#f44336',
+								fontFamily: '"Roboto", sans-serif'
+							},
+						},
+					};
+
+					// Create Reveal Elements With Tokens.
+					const fieldsTokenData = response.records[0].fields;
+					const revealContainer = skyflow.container(
+						Skyflow.ContainerType.REVEAL
+					) as RevealContainer;
+					const revealCardNumberElement: RevealElement = revealContainer.create({
+						token: fieldsTokenData.primary_card.card_number,
+						label: 'Card Number',
+						...revealStyleOptions,
+
+					});
+					revealCardNumberElement.mount('#revealCardNumber');
+
+					const revealCardCvvElement: RevealElement = revealContainer.create({
+						token: fieldsTokenData.primary_card.cvv,
+						label: 'Cvv',
+						...revealStyleOptions,
+
+					});
+					revealCardCvvElement.mount('#revealCvv');
+
+					const revealCardExpiryElement: RevealElement = revealContainer.create({
+						token: fieldsTokenData.primary_card.expiry_date,
+						label: 'Card Expiry Date',
+						...revealStyleOptions,
+					});
+					revealCardExpiryElement.mount('#revealExpiryDate');
+
+					const revealCardholderNameElement: RevealElement = revealContainer.create({
+						token: fieldsTokenData.first_name,
+						label: 'Card Holder Name',
+						...revealStyleOptions,
+					});
+					revealCardholderNameElement.mount('#revealCardholderName');
+
+					const revealButton = document.getElementById('revealPCIData');
+
+					if (revealButton) {
+						revealButton.addEventListener('click', () => {
+							const revealResponse: Promise<RevealResponse> = revealContainer.reveal();
+							revealResponse.then(res => {
+								console.log(res);
+							})
+							.catch(err => {
+								console.error(err);
+							});
+						});
+					}
+				})
+				.catch((err: Error) => {
+					console.error(err);
+				});
+		});
+	}
+} catch (err: unknown) {
+	console.error(err);
+}

--- a/samples/using-typescript/composable-elements/src/index.ts
+++ b/samples/using-typescript/composable-elements/src/index.ts
@@ -46,10 +46,9 @@ try {
 			env: Skyflow.Env.PROD,
 		},
 	}
-	const skyflow = Skyflow.init(config);
+	const skyflow: Skyflow = Skyflow.init(config);
 
 	//custom styles for collect elements
-
 	const cardholderStyles = {
 		inputStyles: {
 			base: {
@@ -124,7 +123,7 @@ try {
 				margin: '12px 2px',
 				boxShadow: '8px'
 			}
-		},
+		} as InputStyles,
 		errorTextStyles: {
 			base: {
 				color: 'red',
@@ -133,7 +132,7 @@ try {
 			global: {
 				'@import' :'url("https://fonts.googleapis.com/css2?family=Roboto&display=swap")',
 			}
-		}
+		} as ErrorTextStyles,
 	}
 	// create collect Container
 	const composableContainer = skyflow.container(Skyflow.ContainerType.COMPOSABLE, containerOptions) as ComposableContainer;

--- a/samples/using-typescript/composable-elements/src/index.ts
+++ b/samples/using-typescript/composable-elements/src/index.ts
@@ -8,7 +8,14 @@ import Skyflow, {
 	CollectResponse,
 	RevealContainer,
 	RevealElement,
-	RevealResponse
+	RevealResponse,
+	CollectElementInput,
+	ISkyflow,
+	InputStyles,
+	LabelStyles,
+	ContainerOptions,
+	ErrorTextStyles,
+	IRevealElementInput,
 } from 'skyflow-js';
 
 try {
@@ -16,7 +23,7 @@ try {
 	if (revealView) {
 		revealView.style.visibility = 'hidden';
 	}
-	const skyflow = Skyflow.init({
+	const config: ISkyflow = {
 		vaultID: '<VAULT_ID>',
 		vaultURL: '<VAULT_URL>',
 		getBearerToken: () => {
@@ -38,15 +45,17 @@ try {
 			logLevel: Skyflow.LogLevel.ERROR,
 			env: Skyflow.Env.PROD,
 		},
-	});
+	}
+	const skyflow = Skyflow.init(config);
 
 	//custom styles for collect elements
+
 	const cardholderStyles = {
 		inputStyles: {
 			base: {
 				fontFamily: '"Roboto", sans-serif',
 				fontStyle: 'normal',
-				fontWeight: 400,
+				fontWeight: '400',
 				fontSize: '14px',
 				lineHeight: '21px',
 				width: '294px'
@@ -54,9 +63,9 @@ try {
 			global: {
 				'@import' :'url("https://fonts.googleapis.com/css2?family=Roboto&display=swap")',
 			}
-		},
+		} as InputStyles,
 		labelStyles: {
-		},
+		} as LabelStyles,
 	};
 
 	const cardNumberStyles = {
@@ -64,15 +73,15 @@ try {
 			base: {
 				fontFamily: '"Roboto", sans-serif',
 				fontStyle: 'normal',
-				fontWeight: 400,
+				fontWeight: '400',
 				fontSize: '14px',
 				lineHeight: '21px',
 				width: '294px',
 				paddingLeft: '18px'
 			},
-		},
+		} as InputStyles,
 		labelStyles: {
-		},
+		} as LabelStyles,
 	};
 
 	const expiryDateStyles = {
@@ -80,14 +89,14 @@ try {
 			base: {
 				fontFamily: '"Roboto", sans-serif',
 				fontStyle: 'normal',
-				fontWeight: 400,
+				fontWeight: '400',
 				fontSize: '14px',
 				lineHeight: '21px',
 				width: '49px'
 			},
-		},
+		} as InputStyles,
 		labelStyles: {
-		},
+		} as LabelStyles,
 	};
 
 	const cvvStyles = {
@@ -95,17 +104,17 @@ try {
 			base: {
 				fontFamily: '"Roboto", sans-serif',
 				fontStyle: 'normal',
-				fontWeight: 400,
+				fontWeight: '400',
 				fontSize: '14px',
 				lineHeight: '21px',
 				width: '30px'
 			},
-		},
+		} as InputStyles,
 		labelStyles: {
-		},
+		} as LabelStyles,
 	};
 
-	const containerOptions = {
+	const containerOptions: ContainerOptions = {
 		layout: [1, 3],
 		styles: {
 			base: {
@@ -129,38 +138,41 @@ try {
 	// create collect Container
 	const composableContainer = skyflow.container(Skyflow.ContainerType.COMPOSABLE, containerOptions) as ComposableContainer;
 
-	const cardHolderNameElement: ComposableElement = composableContainer.create({
+	const cardHolderNameInput: CollectElementInput = {
 		table: 'pii_fields',
 		column: 'first_name',
 		...cardholderStyles,
 		placeholder: 'Cardholder Name',
 		type: Skyflow.ElementType.CARDHOLDER_NAME,
-	});
+	}
+	const cardHolderNameElement: ComposableElement = composableContainer.create(cardHolderNameInput);
 
-	const cardNumberElement: ComposableElement = composableContainer.create({
+	const cardNumberInput: CollectElementInput = {
 		table: 'pii_fields',
 		column: 'primary_card.card_number',
 		...cardNumberStyles,
 		type: Skyflow.ElementType.CARD_NUMBER,
 		placeholder: 'XXXX XXXX XXXX XXXX'
-	});
+	}
+	const cardNumberElement: ComposableElement = composableContainer.create(cardNumberInput);
 
-	const expiryDateElement: ComposableElement = composableContainer.create({
+	const expiryDateInput: CollectElementInput = {
 		table: 'pii_fields',
 		column: 'primary_card.expiry_date',
 		...expiryDateStyles,
 		placeholder: 'MM/YY',
 		type: Skyflow.ElementType.EXPIRATION_DATE,
-	});
+	}
+	const expiryDateElement: ComposableElement = composableContainer.create(expiryDateInput);
 
-
-	const cvvElement: ComposableElement = composableContainer.create({
+	const cvvInput: CollectElementInput = {
 		table: 'pii_fields',
 		column: 'primary_card.cvv',
 		...cvvStyles,
 		placeholder: 'CVC',
 		type: Skyflow.ElementType.CVV,
-	});
+	}
+	const cvvElement: ComposableElement = composableContainer.create(cvvInput);
 
 	// mount the container
 	composableContainer.mount('#composableContainer');
@@ -171,7 +183,7 @@ try {
 		collectButton.addEventListener('click', () => {
 			const collectResponse: Promise<CollectResponse> = composableContainer.collect();
 			collectResponse
-				.then(response => {
+				.then((response: CollectResponse) => {
 					const responseElement = document.getElementById('collectResponse');
 					if (responseElement) {
 						responseElement.innerHTML = JSON.stringify(response, null, 2);
@@ -194,55 +206,58 @@ try {
 							global: {
 								'@import' :'url("https://fonts.googleapis.com/css2?family=Roboto&display=swap")',
 							}
-						},
+						} as InputStyles,
 						labelStyles: {
 							base: {
 								fontSize: '16px',
 								fontWeight: 'bold',
 								fontFamily: '"Roboto", sans-serif'
 							},
-						},
+						} as LabelStyles,
 						errorTextStyles: {
 							base: {
 								color: '#f44336',
 								fontFamily: '"Roboto", sans-serif'
 							},
-						},
+						} as ErrorTextStyles,
 					};
 
 					// Create Reveal Elements With Tokens.
-					const fieldsTokenData = response.records[0].fields;
+					const fieldsTokenData = response.records![0].fields;
 					const revealContainer = skyflow.container(
 						Skyflow.ContainerType.REVEAL
 					) as RevealContainer;
-					const revealCardNumberElement: RevealElement = revealContainer.create({
+
+					const revealCardNumberInput: IRevealElementInput = {
 						token: fieldsTokenData.primary_card.card_number,
 						label: 'Card Number',
 						...revealStyleOptions,
-
-					});
+					};
+					const revealCardNumberElement: RevealElement = revealContainer.create(revealCardNumberInput);
 					revealCardNumberElement.mount('#revealCardNumber');
 
-					const revealCardCvvElement: RevealElement = revealContainer.create({
+					const revealCardCvvInput: IRevealElementInput = {
 						token: fieldsTokenData.primary_card.cvv,
 						label: 'Cvv',
 						...revealStyleOptions,
-
-					});
+					}
+					const revealCardCvvElement: RevealElement = revealContainer.create(revealCardCvvInput);
 					revealCardCvvElement.mount('#revealCvv');
 
-					const revealCardExpiryElement: RevealElement = revealContainer.create({
+					const revealCardExpiryInput: IRevealElementInput = {
 						token: fieldsTokenData.primary_card.expiry_date,
 						label: 'Card Expiry Date',
 						...revealStyleOptions,
-					});
+					};
+					const revealCardExpiryElement: RevealElement = revealContainer.create(revealCardExpiryInput);
 					revealCardExpiryElement.mount('#revealExpiryDate');
 
-					const revealCardholderNameElement: RevealElement = revealContainer.create({
+					const revealCardholderNameInput: IRevealElementInput = {
 						token: fieldsTokenData.first_name,
 						label: 'Card Holder Name',
 						...revealStyleOptions,
-					});
+					}
+					const revealCardholderNameElement: RevealElement = revealContainer.create(revealCardholderNameInput);
 					revealCardholderNameElement.mount('#revealCardholderName');
 
 					const revealButton = document.getElementById('revealPCIData');
@@ -250,16 +265,16 @@ try {
 					if (revealButton) {
 						revealButton.addEventListener('click', () => {
 							const revealResponse: Promise<RevealResponse> = revealContainer.reveal();
-							revealResponse.then(res => {
+							revealResponse.then((res: RevealResponse) => {
 								console.log(res);
 							})
-							.catch(err => {
+							.catch((err: RevealResponse) => {
 								console.error(err);
 							});
 						});
 					}
 				})
-				.catch((err: Error) => {
+				.catch((err: CollectResponse) => {
 					console.error(err);
 				});
 		});

--- a/samples/using-typescript/custom-validations/package.json
+++ b/samples/using-typescript/custom-validations/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "customvalidations",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "start": "parcel src/index.html --open --no-cache",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "license": "ISC",
+  "dependencies": {
+    "skyflow-js": "^2.3.1"
+  },
+  "devDependencies": {
+    "parcel": "^2.0.1"
+  }
+}

--- a/samples/using-typescript/custom-validations/src/index.html
+++ b/samples/using-typescript/custom-validations/src/index.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Custom Validations</title>
+
+    <style>
+      body {
+        display: flex;
+        flex-direction: column;
+      }
+      .empty-div {
+        height: 100px;
+        width: 350px;
+      }
+      .reveal-view {
+        margin-top: 48px;
+      }
+    </style>
+  </head>
+  <body>
+    <h3>Collect Elements</h3>
+    <!-- COllect Part -->
+    <div>
+      <div id="collectUserName" class="empty-div"></div>
+      <div id="collectPassword" class="empty-div"></div>
+      <div id="collectConfirmPassword" class="empty-div"></div>
+    </div>
+
+    <script type="module" src="index.js"></script>
+  </body>
+</html>

--- a/samples/using-typescript/custom-validations/src/index.ts
+++ b/samples/using-typescript/custom-validations/src/index.ts
@@ -4,115 +4,123 @@
 import Skyflow, {
   CollectContainer,
   CollectElement,
+  CollectElementInput,
+  ErrorTextStyles,
+  ISkyflow,
+  InputStyles,
+  IValidationRule,
+  LabelStyles,
 } from 'skyflow-js';
 
 try{
-    const skyflow = Skyflow.init({
-        vaultID: '<VAULT_ID>',
-        vaultURL: '<VAULT_URL>',
-        getBearerToken: () => {
-          return new Promise((resolve, reject) => {
-            const Http = new XMLHttpRequest();
+    const config: ISkyflow = {
+      vaultID: '<VAULT_ID>',
+      vaultURL: '<VAULT_URL>',
+      getBearerToken: () => {
+        return new Promise((resolve, reject) => {
+          const Http = new XMLHttpRequest();
 
-            Http.onreadystatechange = () => {
-              if (Http.readyState === 4 && Http.status === 200) {
-                const response = JSON.parse(Http.responseText);
-                resolve(response.accessToken);
-              }
-            };
-            const url = '<TOKEN_END_POINT_URL>';
-            Http.open('GET', url);
-            Http.send();
-          });
-        },
-        options:{
-          logLevel:Skyflow.LogLevel.ERROR,
-          env:Skyflow.Env.PROD,
-        }
-      });
+          Http.onreadystatechange = () => {
+            if (Http.readyState === 4 && Http.status === 200) {
+              const response = JSON.parse(Http.responseText);
+              resolve(response.accessToken);
+            }
+          };
+          const url = '<TOKEN_END_POINT_URL>';
+          Http.open('GET', url);
+          Http.send();
+        });
+      },
+      options:{
+        logLevel:Skyflow.LogLevel.ERROR,
+        env:Skyflow.Env.PROD,
+      }
+    }
+    const skyflow = Skyflow.init(config);
 
       // Create collect Container.
-      const collectContainer = skyflow.container(Skyflow.ContainerType.COLLECT) as CollectContainer;
+    const collectContainer = skyflow.container(Skyflow.ContainerType.COLLECT) as CollectContainer;
 
-      // Custom styles for collect elements.
-      const collectStylesOptions = {
-        inputStyles: {
-          base: {
-            border: '1px solid #eae8ee',
-            padding: '10px 16px',
-            borderRadius: '4px',
-            color: '#1d1d1d',
-            marginTop: '4px',
-          },
-          complete: {
-            color: '#4caf50',
-          },
-          empty: {},
-          focus: {},
-          invalid: {
-            color: '#f44336',
-          },
+    // Custom styles for collect elements.
+    const collectStylesOptions = {
+      inputStyles: {
+        base: {
+          border: '1px solid #eae8ee',
+          padding: '10px 16px',
+          borderRadius: '4px',
+          color: '#1d1d1d',
+          marginTop: '4px',
         },
-        labelStyles: {
-          base: {
-            fontSize: '16px',
-            fontWeight: 'bold',
-          },
+        complete: {
+          color: '#4caf50',
         },
-        errorTextStyles: {
-          base: {
-            color: '#f44336',
-          },
+        empty: {},
+        focus: {},
+        invalid: {
+          color: '#f44336',
         },
-      };
-
+      } as InputStyles,
+      labelStyles: {
+        base: {
+          fontSize: '16px',
+          fontWeight: 'bold',
+        },
+      } as LabelStyles,
+      errorTextStyles: {
+        base: {
+          color: '#f44336',
+        },
+      } as ErrorTextStyles,
+    };
 
       // Create a validation rule.
-      const regexRule = {
-        // REGEX Rule will validate the element value with the given regex
-        type:Skyflow.ValidationRuleType.REGEX_MATCH_RULE ,
-        params:{
-            // regex rule expects a regex to be tested on element value
-            regex:/[A-Za-z0-9]+/,
-            // specify what error text should be displayed 
-            // when this validation rule failed
-            error:'only alphabets are allowed'
-        }
+    const regexRule: IValidationRule = {
+      // REGEX Rule will validate the element value with the given regex
+      type:Skyflow.ValidationRuleType.REGEX_MATCH_RULE ,
+      params:{
+          // regex rule expects a regex to be tested on element value
+          regex:/[A-Za-z0-9]+/,
+          // specify what error text should be displayed 
+          // when this validation rule failed
+          error:'only alphabets are allowed'
       }
-      // Creating a length rule.
-      const lengthRule = {
-        // LENGTH match rule will validate whether the element value length matches with given length.  
-        type:Skyflow.ValidationRuleType.LENGTH_MATCH_RULE,
-        params:{
-            // specify minimum length that element value should have
-            min:3,
-            // specify maximum length that element value should have
-            max:12,
-            // specify what error text should be displayed 
-            // when this validation rule failed
-            error:'must be between 3 to 12 alphabets'
-        }
+    }
+    // Creating a length rule.
+    const lengthRule: IValidationRule = {
+      // LENGTH match rule will validate whether the element value length matches with given length.  
+      type:Skyflow.ValidationRuleType.LENGTH_MATCH_RULE,
+      params:{
+          // specify minimum length that element value should have
+          min:3,
+          // specify maximum length that element value should have
+          max:12,
+          // specify what error text should be displayed 
+          // when this validation rule failed
+          error:'must be between 3 to 12 alphabets'
       }
+    }
       
-      const userNameElement: CollectElement = collectContainer.create({
-        table: 'pii_fields',
-        column: 'first_name',
-        ...collectStylesOptions,
-        placeholder: 'Enter User Name',
-        label: 'User Name',
-        type: Skyflow.ElementType.INPUT_FIELD,
-        // pass validation rules
-        validations:[regexRule,lengthRule]
-      });
+    const userNameInput: CollectElementInput = {
+      table: 'pii_fields',
+      column: 'first_name',
+      ...collectStylesOptions,
+      placeholder: 'Enter User Name',
+      label: 'User Name',
+      type: Skyflow.ElementType.INPUT_FIELD,
+      // pass validation rules
+      validations:[regexRule,lengthRule]
+    }
+    const userNameElement: CollectElement = collectContainer.create(userNameInput);
 
-      const passwordElement: CollectElement = collectContainer.create({
-        ...collectStylesOptions,
-        label: 'Enter Password',
-        placeholder: 'Password',
-        type: Skyflow.ElementType.INPUT_FIELD,
-      });
+    const passwordInput: CollectElementInput = {
+      ...collectStylesOptions,
+      label: 'Enter Password',
+      placeholder: 'Password',
+      type: Skyflow.ElementType.INPUT_FIELD,
+    }
+    const passwordElement: CollectElement = collectContainer.create(passwordInput);
 
-    const elementMatchRule = {
+    const elementMatchRule: IValidationRule = {
       // ELEMENT VALUE MATCH RULE validates that element value matches the provied element.
 	    type: Skyflow.ValidationRuleType.ELEMENT_VALUE_MATCH_RULE,
 	    params: {
@@ -124,21 +132,21 @@ try{
 	    }
     }
 
-      const confirmPasswordElement: CollectElement = collectContainer.create({
-        ...collectStylesOptions,
-        label: 'Confirm Password',
-        placeholder: 'confirm password',
-        type: Skyflow.ElementType.INPUT_FIELD,
-        // Add validations.
-        validations:[elementMatchRule]
-      });
+    const confirmPasswordInput: CollectElementInput = {
+      ...collectStylesOptions,
+      label: 'Confirm Password',
+      placeholder: 'confirm password',
+      type: Skyflow.ElementType.INPUT_FIELD,
+      // Add validations.
+      validations:[elementMatchRule]
+    }
+    const confirmPasswordElement: CollectElement = collectContainer.create(confirmPasswordInput);
 
+    // Mount the elements.
+    userNameElement.mount('#collectUserName');
+    passwordElement.mount('#collectPassword');
+    confirmPasswordElement.mount('#collectConfirmPassword');
 
-      // Mount the elements.
-      userNameElement.mount('#collectUserName');
-      passwordElement.mount('#collectPassword');
-      confirmPasswordElement.mount('#collectConfirmPassword');
-
-}catch(err){
+} catch (err: unknown) {
     console.log(err);
 }

--- a/samples/using-typescript/custom-validations/src/index.ts
+++ b/samples/using-typescript/custom-validations/src/index.ts
@@ -36,7 +36,7 @@ try{
         env:Skyflow.Env.PROD,
       }
     }
-    const skyflow = Skyflow.init(config);
+    const skyflow: Skyflow = Skyflow.init(config);
 
       // Create collect Container.
     const collectContainer = skyflow.container(Skyflow.ContainerType.COLLECT) as CollectContainer;
@@ -124,11 +124,11 @@ try{
       // ELEMENT VALUE MATCH RULE validates that element value matches the provied element.
 	    type: Skyflow.ValidationRuleType.ELEMENT_VALUE_MATCH_RULE,
 	    params: {
-            // Specify with which element value should be matched.
-	        element: passwordElement,
-            // Specify what error text should be displayed 
-            // when this validation rule failed
-            error: 'password doesn’t match'
+        // Specify with which element value should be matched.
+        element: passwordElement,
+        // Specify what error text should be displayed 
+        // when this validation rule failed
+        error: 'password doesn’t match'
 	    }
     }
 

--- a/samples/using-typescript/custom-validations/src/index.ts
+++ b/samples/using-typescript/custom-validations/src/index.ts
@@ -1,0 +1,144 @@
+/*
+  Copyright (c) 2025 Skyflow, Inc.
+*/
+import Skyflow, {
+  CollectContainer,
+  CollectElement,
+} from 'skyflow-js';
+
+try{
+    const skyflow = Skyflow.init({
+        vaultID: '<VAULT_ID>',
+        vaultURL: '<VAULT_URL>',
+        getBearerToken: () => {
+          return new Promise((resolve, reject) => {
+            const Http = new XMLHttpRequest();
+
+            Http.onreadystatechange = () => {
+              if (Http.readyState === 4 && Http.status === 200) {
+                const response = JSON.parse(Http.responseText);
+                resolve(response.accessToken);
+              }
+            };
+            const url = '<TOKEN_END_POINT_URL>';
+            Http.open('GET', url);
+            Http.send();
+          });
+        },
+        options:{
+          logLevel:Skyflow.LogLevel.ERROR,
+          env:Skyflow.Env.PROD,
+        }
+      });
+
+      // Create collect Container.
+      const collectContainer = skyflow.container(Skyflow.ContainerType.COLLECT) as CollectContainer;
+
+      // Custom styles for collect elements.
+      const collectStylesOptions = {
+        inputStyles: {
+          base: {
+            border: '1px solid #eae8ee',
+            padding: '10px 16px',
+            borderRadius: '4px',
+            color: '#1d1d1d',
+            marginTop: '4px',
+          },
+          complete: {
+            color: '#4caf50',
+          },
+          empty: {},
+          focus: {},
+          invalid: {
+            color: '#f44336',
+          },
+        },
+        labelStyles: {
+          base: {
+            fontSize: '16px',
+            fontWeight: 'bold',
+          },
+        },
+        errorTextStyles: {
+          base: {
+            color: '#f44336',
+          },
+        },
+      };
+
+
+      // Create a validation rule.
+      const regexRule = {
+        // REGEX Rule will validate the element value with the given regex
+        type:Skyflow.ValidationRuleType.REGEX_MATCH_RULE ,
+        params:{
+            // regex rule expects a regex to be tested on element value
+            regex:/[A-Za-z0-9]+/,
+            // specify what error text should be displayed 
+            // when this validation rule failed
+            error:'only alphabets are allowed'
+        }
+      }
+      // Creating a length rule.
+      const lengthRule = {
+        // LENGTH match rule will validate whether the element value length matches with given length.  
+        type:Skyflow.ValidationRuleType.LENGTH_MATCH_RULE,
+        params:{
+            // specify minimum length that element value should have
+            min:3,
+            // specify maximum length that element value should have
+            max:12,
+            // specify what error text should be displayed 
+            // when this validation rule failed
+            error:'must be between 3 to 12 alphabets'
+        }
+      }
+      
+      const userNameElement: CollectElement = collectContainer.create({
+        table: 'pii_fields',
+        column: 'first_name',
+        ...collectStylesOptions,
+        placeholder: 'Enter User Name',
+        label: 'User Name',
+        type: Skyflow.ElementType.INPUT_FIELD,
+        // pass validation rules
+        validations:[regexRule,lengthRule]
+      });
+
+      const passwordElement: CollectElement = collectContainer.create({
+        ...collectStylesOptions,
+        label: 'Enter Password',
+        placeholder: 'Password',
+        type: Skyflow.ElementType.INPUT_FIELD,
+      });
+
+    const elementMatchRule = {
+      // ELEMENT VALUE MATCH RULE validates that element value matches the provied element.
+	    type: Skyflow.ValidationRuleType.ELEMENT_VALUE_MATCH_RULE,
+	    params: {
+            // Specify with which element value should be matched.
+	        element: passwordElement,
+            // Specify what error text should be displayed 
+            // when this validation rule failed
+            error: 'password doesn’t match'
+	    }
+    }
+
+      const confirmPasswordElement: CollectElement = collectContainer.create({
+        ...collectStylesOptions,
+        label: 'Confirm Password',
+        placeholder: 'confirm password',
+        type: Skyflow.ElementType.INPUT_FIELD,
+        // Add validations.
+        validations:[elementMatchRule]
+      });
+
+
+      // Mount the elements.
+      userNameElement.mount('#collectUserName');
+      passwordElement.mount('#collectPassword');
+      confirmPasswordElement.mount('#collectConfirmPassword');
+
+}catch(err){
+    console.log(err);
+}

--- a/samples/using-typescript/file-render/package.json
+++ b/samples/using-typescript/file-render/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "filerender",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "start": "parcel src/index.html --open"
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "skyflow-js": "^2.3.1"
+  },
+  "devDependencies": {
+    "parcel": "^2.0.1"
+  }
+}

--- a/samples/using-typescript/file-render/src/index.html
+++ b/samples/using-typescript/file-render/src/index.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>File render elements</title>
+    <style>
+      body {
+      display: flex;
+      flex-direction: column;
+      }
+      .empty-div {
+      width: 100%;
+      }
+      .render-view {
+      margin-top: 48px;
+      }
+    </style>
+  </head>
+  <body>
+    <h3>Render File Elements</h3>
+    <h4>File Element 1</h4>
+    <div id="renderFileElement1" class="empty-div"></div>
+    <h4>File Element 2</h4>
+    <div id="renderFileElement2" class="empty-div"></div>
+    <br>
+    <div id="renderCardNumber" class="empty-div"></div>
+    <div id="renderCvv" class="empty-div"></div>
+    <button id="renderFiles" style="height: 30px; width: 200px;">Render Files</button>
+    </div>
+    <script type="module" src="index.js"></script>
+  </body>
+</html>

--- a/samples/using-typescript/file-render/src/index.ts
+++ b/samples/using-typescript/file-render/src/index.ts
@@ -30,7 +30,7 @@ try {
       });
     },
   }
-  const skyflow = Skyflow.init(config);
+  const skyflow: Skyflow = Skyflow.init(config);
 
   const renderStyleOptions = {
     inputStyles: {

--- a/samples/using-typescript/file-render/src/index.ts
+++ b/samples/using-typescript/file-render/src/index.ts
@@ -2,13 +2,16 @@
   Copyright (c) 2025 Skyflow, Inc.
 */
 import Skyflow, {
+  ErrorTextStyles,
+  ISkyflow,
+  InputStyles,
+  IRevealElementInput,
   RevealContainer,
   RevealElement,
-  RenderFileResponse,
 } from "skyflow-js";
 
 try {
-  const skyflow = Skyflow.init({
+  const config: ISkyflow = {
     vaultID: "<VAULT_ID>",
     vaultURL: "<VAULT_URL>",
     getBearerToken: () => {
@@ -26,7 +29,8 @@ try {
         Http.send();
       });
     },
-  });
+  }
+  const skyflow = Skyflow.init(config);
 
   const renderStyleOptions = {
     inputStyles: {
@@ -39,12 +43,12 @@ try {
         height: "250px",
         width: "400px",
       },
-    },
+    } as InputStyles,
     errorTextStyles: {
       base: {
         color: "#f44336",
       },
-    },
+    } as ErrorTextStyles,
   };
 
   const renderStyleOptions2 = {
@@ -58,32 +62,34 @@ try {
         height: "260px",
         width: "400px",
       },
-    },
+    } as InputStyles,
     errorTextStyles: {
       base: {
         color: "yellow",
       },
-    },
+    } as ErrorTextStyles,
   };
 
   const renderContainer = skyflow.container(Skyflow.ContainerType.REVEAL) as RevealContainer;
 
-  const renderFileElement1: RevealElement = renderContainer.create({
+  const renderFileInput1: IRevealElementInput = {
     ...renderStyleOptions,
     skyflowID: "<SKYFLOW_ID1>",
     column: "<COLUMN_NAME1>",
     table: "<TABLE1>",
     altText: "Alt text 1",
-  });
+  }
+  const renderFileElement1: RevealElement = renderContainer.create(renderFileInput1);
   renderFileElement1.mount("#renderFileElement1");
 
-  const renderFileElement2: RevealElement = renderContainer.create({
+  const renderFileInput2: IRevealElementInput = {
     ...renderStyleOptions2,
     skyflowID: "<SKYFLOW_ID2>",
     column: "<COLUMN_NAME2>",
     table: "<TABLE2>",
     altText: "Alt text 2",
-  });
+  }
+  const renderFileElement2: RevealElement = renderContainer.create(renderFileInput2);
 
   renderFileElement2.mount("#renderFileElement2");
 
@@ -92,22 +98,22 @@ try {
   if (renderButton) {
     renderButton.addEventListener("click", () => {
       const renderFile1Response = renderFileElement1.renderFile();
-      renderFile1Response.then((res) => {
+      renderFile1Response.then((res: any) => {
         console.log("response 1", res);
       })
-      .catch((err) => {
+      .catch((err: any) => {
         console.log("Error 1", err);
       });
 
       const renderFile2Response = renderFileElement2.renderFile();
-      renderFile2Response.then((res) => {
+      renderFile2Response.then((res: any) => {
         console.log("response 2", res);
       })
-      .catch((err) => {
+      .catch((err: any) => {
         console.log("Error 2", err);
       });
     });
   }
-} catch (err) {
+} catch (err: unknown) {
   console.log(err);
 }

--- a/samples/using-typescript/file-render/src/index.ts
+++ b/samples/using-typescript/file-render/src/index.ts
@@ -1,0 +1,113 @@
+/*
+  Copyright (c) 2025 Skyflow, Inc.
+*/
+import Skyflow, {
+  RevealContainer,
+  RevealElement,
+  RenderFileResponse,
+} from "skyflow-js";
+
+try {
+  const skyflow = Skyflow.init({
+    vaultID: "<VAULT_ID>",
+    vaultURL: "<VAULT_URL>",
+    getBearerToken: () => {
+      return new Promise((resolve, reject) => {
+        const Http = new XMLHttpRequest();
+
+        Http.onreadystatechange = () => {
+          if (Http.readyState === 4 && Http.status === 200) {
+            const response = JSON.parse(Http.responseText);
+            resolve(response.accessToken);
+          }
+        };
+        const url = "<TOKEN_END_POINT_URL>";
+        Http.open("GET", url);
+        Http.send();
+      });
+    },
+  });
+
+  const renderStyleOptions = {
+    inputStyles: {
+      base: {
+        border: "2px solid #eae8ee",
+        padding: "10px 10px 10px 10px",
+        borderRadius: "10px",
+        color: "#1d1d1d",
+        marginTop: "2px",
+        height: "250px",
+        width: "400px",
+      },
+    },
+    errorTextStyles: {
+      base: {
+        color: "#f44336",
+      },
+    },
+  };
+
+  const renderStyleOptions2 = {
+    inputStyles: {
+      base: {
+        border: "2px solid orange",
+        padding: "10px 10px 10px 10px",
+        borderRadius: "10px",
+        color: "#1d1d1d",
+        marginTop: "4px",
+        height: "260px",
+        width: "400px",
+      },
+    },
+    errorTextStyles: {
+      base: {
+        color: "yellow",
+      },
+    },
+  };
+
+  const renderContainer = skyflow.container(Skyflow.ContainerType.REVEAL) as RevealContainer;
+
+  const renderFileElement1: RevealElement = renderContainer.create({
+    ...renderStyleOptions,
+    skyflowID: "<SKYFLOW_ID1>",
+    column: "<COLUMN_NAME1>",
+    table: "<TABLE1>",
+    altText: "Alt text 1",
+  });
+  renderFileElement1.mount("#renderFileElement1");
+
+  const renderFileElement2: RevealElement = renderContainer.create({
+    ...renderStyleOptions2,
+    skyflowID: "<SKYFLOW_ID2>",
+    column: "<COLUMN_NAME2>",
+    table: "<TABLE2>",
+    altText: "Alt text 2",
+  });
+
+  renderFileElement2.mount("#renderFileElement2");
+
+  const renderButton = document.getElementById("renderFiles");
+
+  if (renderButton) {
+    renderButton.addEventListener("click", () => {
+      const renderFile1Response = renderFileElement1.renderFile();
+      renderFile1Response.then((res) => {
+        console.log("response 1", res);
+      })
+      .catch((err) => {
+        console.log("Error 1", err);
+      });
+
+      const renderFile2Response = renderFileElement2.renderFile();
+      renderFile2Response.then((res) => {
+        console.log("response 2", res);
+      })
+      .catch((err) => {
+        console.log("Error 2", err);
+      });
+    });
+  }
+} catch (err) {
+  console.log(err);
+}

--- a/samples/using-typescript/pure-js-delete/.gitignore
+++ b/samples/using-typescript/pure-js-delete/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+.parcel-cache/
+dist/
+package-lock.json

--- a/samples/using-typescript/pure-js-delete/package.json
+++ b/samples/using-typescript/pure-js-delete/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "pure-js-delete",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "start": "parcel src/index.html --open",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "dependencies": {
+    "skyflow-js": "^2.3.1"
+  },
+  "devDependencies": {
+    "parcel": "^2.0.1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC"
+}

--- a/samples/using-typescript/pure-js-delete/src/index.html
+++ b/samples/using-typescript/pure-js-delete/src/index.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Pure Js Delete</title>
+    <style>
+      .field {
+        padding: 8px;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="deleteView">
+      <h3>Delete</h3>
+      <form>
+        <button id="deleteButton" type="button">Delete</button>
+      </form>
+
+      <div>
+        <h3>Delete Response</h3>
+        <pre id="deleteResponse"></pre>
+      </div>
+    </div>
+    <script type="module" src="index.js"></script>
+  </body>
+</html>

--- a/samples/using-typescript/pure-js-delete/src/index.ts
+++ b/samples/using-typescript/pure-js-delete/src/index.ts
@@ -1,0 +1,63 @@
+/*
+  Copyright (c) 2025 Skyflow, Inc.
+*/
+import Skyflow, { DeleteResponse } from "skyflow-js";
+
+try {
+  const skyflow = Skyflow.init({
+    vaultID: "<VAULT_ID>",
+    vaultURL: "<VAULT_URL>",
+    getBearerToken: () => {
+      return new Promise((resolve, reject) => {
+        const Http = new XMLHttpRequest();
+
+        Http.onreadystatechange = () => {
+          if (Http.readyState === 4 && Http.status === 200) {
+            const response = JSON.parse(Http.responseText);
+            resolve(response.accessToken);
+          }
+        };
+        const url = "<TOKEN_END_POINT_URL>";
+        Http.open("GET", url);
+        Http.send();
+      });
+    },
+  });
+
+  // form delete request
+  const deleteButton = document.getElementById("deleteButton");
+  if (deleteButton) {
+    deleteButton.addEventListener("click", () => {
+      const response: Promise<DeleteResponse> = skyflow.delete({
+        records: [
+          { id: "<SKYFLOW_ID_1>", table: "<TABLE_NAME>" },
+          { id: "<SKYFLOW_ID_2>", table: "<TABLE_NAME>" },
+        ],
+      });
+
+      response
+        .then(
+          (res) => {
+            const element = document.getElementById("deleteResponse");
+            if (element) {
+              element.innerHTML = JSON.stringify(res, null, 2);
+            }
+          },
+          (err) => {
+            const element = document.getElementById("deleteResponse");
+            if (element) {
+              element.innerHTML = JSON.stringify(err, null, 2);
+            }
+          }
+        )
+        .catch((err) => {
+          const element = document.getElementById("deleteResponse");
+          if (element) {
+            element.innerHTML = JSON.stringify(err, null, 2);
+          }
+        });
+    });
+  }
+} catch (err: unknown) {
+  console.error(err);
+}

--- a/samples/using-typescript/pure-js-delete/src/index.ts
+++ b/samples/using-typescript/pure-js-delete/src/index.ts
@@ -28,7 +28,7 @@ try {
       });
     },
   }
-  const skyflow = Skyflow.init(config);
+  const skyflow: Skyflow = Skyflow.init(config);
 
   // form delete request
   const deleteButton = document.getElementById("deleteButton");

--- a/samples/using-typescript/pure-js-delete/src/index.ts
+++ b/samples/using-typescript/pure-js-delete/src/index.ts
@@ -1,10 +1,15 @@
 /*
   Copyright (c) 2025 Skyflow, Inc.
 */
-import Skyflow, { DeleteResponse } from "skyflow-js";
+import Skyflow, { 
+  DeleteResponse,
+  IDeleteRecordInput,
+  IDeleteRecord,
+  ISkyflow,
+} from "skyflow-js";
 
 try {
-  const skyflow = Skyflow.init({
+  const config: ISkyflow = {
     vaultID: "<VAULT_ID>",
     vaultURL: "<VAULT_URL>",
     getBearerToken: () => {
@@ -22,35 +27,38 @@ try {
         Http.send();
       });
     },
-  });
+  }
+  const skyflow = Skyflow.init(config);
 
   // form delete request
   const deleteButton = document.getElementById("deleteButton");
   if (deleteButton) {
     deleteButton.addEventListener("click", () => {
-      const response: Promise<DeleteResponse> = skyflow.delete({
-        records: [
-          { id: "<SKYFLOW_ID_1>", table: "<TABLE_NAME>" },
-          { id: "<SKYFLOW_ID_2>", table: "<TABLE_NAME>" },
-        ],
-      });
+      const deleteRecords: Array<IDeleteRecord> = [
+        { id: "<SKYFLOW_ID_1>", table: "<TABLE_NAME>" },
+        { id: "<SKYFLOW_ID_2>", table: "<TABLE_NAME>" },
+      ];
+      const deleteRecordsInput: IDeleteRecordInput = {
+        records: deleteRecords
+      };
+      const response: Promise<DeleteResponse> = skyflow.delete(deleteRecordsInput);
 
       response
         .then(
-          (res) => {
+          (res: DeleteResponse) => {
             const element = document.getElementById("deleteResponse");
             if (element) {
               element.innerHTML = JSON.stringify(res, null, 2);
             }
           },
-          (err) => {
+          (err: DeleteResponse) => {
             const element = document.getElementById("deleteResponse");
             if (element) {
               element.innerHTML = JSON.stringify(err, null, 2);
             }
           }
         )
-        .catch((err) => {
+        .catch((err: DeleteResponse) => {
           const element = document.getElementById("deleteResponse");
           if (element) {
             element.innerHTML = JSON.stringify(err, null, 2);

--- a/samples/using-typescript/pure-js-get/package.json
+++ b/samples/using-typescript/pure-js-get/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "purejs-get",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "type": "module",
+  "scripts": {
+    "start": "parcel src/index.html --open",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "license": "ISC",
+  "devDependencies": {
+    "parcel": "^2.0.1"
+  },
+  "dependencies": {
+    "ts-node": "^10.9.1",
+    "skyflow-js": "^2.3.1"
+  }
+}

--- a/samples/using-typescript/pure-js-get/src/index.html
+++ b/samples/using-typescript/pure-js-get/src/index.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Pure Js Get </title>
+    <style>
+      .field {
+        padding: 8px;
+      }
+    </style>
+  </head>
+  <body>
+    <div>
+      <h3>Get Records</h3>
+      <form>
+        <button id="getButton" type="button">get data</button>
+        <button id="getTokens" type="button">get tokens</button>
+      </form>
+      <div>
+        <h3>Get Record Response</h3>
+        <pre id="getResponse"></pre>
+      </div>
+    </div>
+    <br /> 
+    <script type="module" src="index.js"></script>
+  </body>
+</html>

--- a/samples/using-typescript/pure-js-get/src/index.ts
+++ b/samples/using-typescript/pure-js-get/src/index.ts
@@ -1,10 +1,16 @@
 /*
 Copyright (c) 2025 Skyflow, Inc.
 */
-import Skyflow, { GetResponse } from "skyflow-js";
+import Skyflow, { 
+  GetResponse,
+  IGetInput,
+  IGetOptions,
+  IGetRecord,
+  ISkyflow,
+} from "skyflow-js";
 
 try {
-  const skyflow = Skyflow.init({
+  const config: ISkyflow = {
     vaultID: "<VAULT_ID>",
     vaultURL: "<VAULT_URL>",
     getBearerToken: () => {
@@ -26,35 +32,38 @@ try {
       logLevel: Skyflow.LogLevel.ERROR,
       env: Skyflow.Env.PROD,
     },
-  });
+  }
+  const skyflow = Skyflow.init(config);
   // form get request
   const getButton = document.getElementById("getButton");
   if (getButton) {
     getButton.addEventListener("click", () => {
-      const response: Promise<GetResponse> = skyflow.get({
-        records: [
-          {
-            ids: ["<SKYFLOW_ID1>", "<SKYFLOW_ID2>"],
-            table: "<TABLE_NAME>",
-            redaction: Skyflow.RedactionType.PLAIN_TEXT,
-          },
-          {
-            columnValues: ["<COLUMN_VALUE1>", "<COLUMN_VALUE2>"],
-            columnName: "<UNIQUE_COLUMN_NAME>",
-            table: "<TABLE_NAME>",
-            redaction: Skyflow.RedactionType.PLAIN_TEXT,
-          },
-        ],
-      });
+      const getRecords: Array<IGetRecord> = [
+        {
+          ids: ["<SKYFLOW_ID1>", "<SKYFLOW_ID2>"],
+          table: "<TABLE_NAME>",
+          redaction: Skyflow.RedactionType.PLAIN_TEXT,
+        },
+        {
+          columnValues: ["<COLUMN_VALUE1>", "<COLUMN_VALUE2>"],
+          columnName: "<UNIQUE_COLUMN_NAME>",
+          table: "<TABLE_NAME>",
+          redaction: Skyflow.RedactionType.PLAIN_TEXT,
+        },
+      ];
+      const getRecordsInput: IGetInput = {
+        records: getRecords
+      };
+      const response: Promise<GetResponse> = skyflow.get(getRecordsInput);
 
       response
-        .then((res) => {
+        .then((res: GetResponse) => {
           const getResponseElement = document.getElementById("getResponse");
           if (getResponseElement) {
             getResponseElement.innerHTML = JSON.stringify(res, null, 2);
           }
         })
-        .catch((err) => {
+        .catch((err: GetResponse) => {
           const getResponseElement = document.getElementById("getResponse");
           if (getResponseElement) {
             getResponseElement.innerHTML = JSON.stringify(err, null, 2);
@@ -67,26 +76,29 @@ try {
   const getTokensButton = document.getElementById("getTokens");
   if (getTokensButton) {
     getTokensButton.addEventListener("click", () => {
-      const response: Promise<GetResponse> = skyflow.get(
+      const getRecords: Array<IGetRecord> = [
         {
-          records: [
-            {
-              ids: ["<SKYFLOW_ID1>", "<SKYFLOW_ID2>"],
-              table: "<TABLE_NAME>",
-            },
-          ],
+          ids: ["<SKYFLOW_ID1>", "<SKYFLOW_ID2>"],
+          table: "<TABLE_NAME>",
         },
-        { tokens: true }
+      ];
+      const getRecordsInput: IGetInput = {
+        records: getRecords
+      };
+      const getOptions: IGetOptions = { tokens: true }
+      const response: Promise<GetResponse> = skyflow.get(
+        getRecordsInput,
+        getOptions,
       );
 
       response
-        .then((res) => {
+        .then((res: GetResponse) => {
           const getResponseElement = document.getElementById("getResponse");
           if (getResponseElement) {
             getResponseElement.innerHTML = JSON.stringify(res, null, 2);
           }
         })
-        .catch((err) => {
+        .catch((err: GetResponse) => {
           const getResponseElement = document.getElementById("getResponse");
           if (getResponseElement) {
             getResponseElement.innerHTML = JSON.stringify(err, null, 2);
@@ -95,6 +107,6 @@ try {
         });
     });
   }
-} catch (err) {
+} catch (err: unknown) {
   console.log(err);
 }

--- a/samples/using-typescript/pure-js-get/src/index.ts
+++ b/samples/using-typescript/pure-js-get/src/index.ts
@@ -33,7 +33,7 @@ try {
       env: Skyflow.Env.PROD,
     },
   }
-  const skyflow = Skyflow.init(config);
+  const skyflow: Skyflow = Skyflow.init(config);
   // form get request
   const getButton = document.getElementById("getButton");
   if (getButton) {

--- a/samples/using-typescript/pure-js-get/src/index.ts
+++ b/samples/using-typescript/pure-js-get/src/index.ts
@@ -1,0 +1,100 @@
+/*
+Copyright (c) 2025 Skyflow, Inc.
+*/
+import Skyflow, { GetResponse } from "skyflow-js";
+
+try {
+  const skyflow = Skyflow.init({
+    vaultID: "<VAULT_ID>",
+    vaultURL: "<VAULT_URL>",
+    getBearerToken: () => {
+      return new Promise((resolve, reject) => {
+        const Http = new XMLHttpRequest();
+
+        Http.onreadystatechange = () => {
+          if (Http.readyState === 4 && Http.status === 200) {
+            const response = JSON.parse(Http.responseText);
+            resolve(response.accessToken);
+          }
+        };
+        const url = "<TOKEN_END_POINT_URL>";
+        Http.open("GET", url);
+        Http.send();
+      });
+    },
+    options: {
+      logLevel: Skyflow.LogLevel.ERROR,
+      env: Skyflow.Env.PROD,
+    },
+  });
+  // form get request
+  const getButton = document.getElementById("getButton");
+  if (getButton) {
+    getButton.addEventListener("click", () => {
+      const response: Promise<GetResponse> = skyflow.get({
+        records: [
+          {
+            ids: ["<SKYFLOW_ID1>", "<SKYFLOW_ID2>"],
+            table: "<TABLE_NAME>",
+            redaction: Skyflow.RedactionType.PLAIN_TEXT,
+          },
+          {
+            columnValues: ["<COLUMN_VALUE1>", "<COLUMN_VALUE2>"],
+            columnName: "<UNIQUE_COLUMN_NAME>",
+            table: "<TABLE_NAME>",
+            redaction: Skyflow.RedactionType.PLAIN_TEXT,
+          },
+        ],
+      });
+
+      response
+        .then((res) => {
+          const getResponseElement = document.getElementById("getResponse");
+          if (getResponseElement) {
+            getResponseElement.innerHTML = JSON.stringify(res, null, 2);
+          }
+        })
+        .catch((err) => {
+          const getResponseElement = document.getElementById("getResponse");
+          if (getResponseElement) {
+            getResponseElement.innerHTML = JSON.stringify(err, null, 2);
+          }
+          console.log(err);
+        });
+    });
+  }
+
+  const getTokensButton = document.getElementById("getTokens");
+  if (getTokensButton) {
+    getTokensButton.addEventListener("click", () => {
+      const response: Promise<GetResponse> = skyflow.get(
+        {
+          records: [
+            {
+              ids: ["<SKYFLOW_ID1>", "<SKYFLOW_ID2>"],
+              table: "<TABLE_NAME>",
+            },
+          ],
+        },
+        { tokens: true }
+      );
+
+      response
+        .then((res) => {
+          const getResponseElement = document.getElementById("getResponse");
+          if (getResponseElement) {
+            getResponseElement.innerHTML = JSON.stringify(res, null, 2);
+          }
+        })
+        .catch((err) => {
+          const getResponseElement = document.getElementById("getResponse");
+          if (getResponseElement) {
+            getResponseElement.innerHTML = JSON.stringify(err, null, 2);
+          }
+          console.log(err);
+        });
+    });
+  }
+} catch (err) {
+  console.log(err);
+}

--- a/samples/using-typescript/pure-js/package.json
+++ b/samples/using-typescript/pure-js/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "purejs",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "start": "parcel src/index.html --open",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "license": "ISC",
+  "dependencies": {
+    "skyflow-js": "^2.3.1"
+  },
+  "devDependencies": {
+    "parcel": "^2.0.1"
+  }
+}

--- a/samples/using-typescript/pure-js/src/index.html
+++ b/samples/using-typescript/pure-js/src/index.html
@@ -1,0 +1,85 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Pure Js Insert and Reveal</title>
+    <style>
+      .field {
+        padding: 8px;
+      }
+    </style>
+  </head>
+  <body>
+    <div>
+      <h3>Insert</h3>
+      <form>
+        <div id="cardNumberContainer" class="field">
+          <label for="cardNumber">Card Number</label>
+          <br />
+          <input
+            id="cardNumber"
+            type="text"
+            placeholder="card number"
+            name="cardNumber"
+          />
+        </div>
+        <div id="cardCvvContainer" class="field">
+          <label for="cardCvv">CVV</label>
+          <br />
+          <input id="cardCvv" type="text" placeholder="cvv" minlength="4" />
+        </div>
+        <div id="cardExpiryDateContainer" class="field">
+          <label>Expiry Date</label>
+          <br />
+          <input id="cardExpiry" type="text" placeholder="MM/YYYY" />
+        </div>
+        <div id="cardHolderNameContainer" class="field">
+          <label>Card Holder Name</label>
+          <br />
+          <input
+            id="cardHolderName"
+            type="text"
+            placeholder="card holder name"
+          />
+        </div>
+        <br />
+        <br />
+        <button id="insertButton" type="button">Insert</button>
+      </form>
+      <div>
+        <h3>Insert Response</h3>
+        <pre id="insertResponse"></pre>
+      </div>
+    </div>
+    <br />
+    <div id="revealView">
+      <h3>Reveal</h3>
+      <div>
+        <p>Card Number</p>
+        <p id="card_number"></p>
+      </div>
+      <div>
+        <p>Card CVV</p>
+        <p id="cvv"></p>
+      </div>
+      <div>
+        <p>Card Expiry Date</p>
+        <p id="expiry_date"></p>
+      </div>
+      <div>
+        <p>CardHolder Name</p>
+        <p id="first_name"></p>
+      </div>
+      <div>
+        <button id="revealButton">Detokenize</button>
+      </div>
+      <div>
+        <h3>Detokenize Response</h3>
+        <pre id="revealResponse"></pre>
+      </div>
+    </div>
+    <script type="module" src="index.js"></script>
+  </body>
+</html>

--- a/samples/using-typescript/pure-js/src/index.ts
+++ b/samples/using-typescript/pure-js/src/index.ts
@@ -1,0 +1,172 @@
+/*
+  Copyright (c) 2025 Skyflow, Inc.
+*/
+import Skyflow, { 
+  InsertResponse, 
+  DetokenizeResponse,
+} from 'skyflow-js';
+
+try {
+  const revealView = document.getElementById('revealView');
+  if (revealView) {
+    revealView.style.visibility = 'hidden';
+  }
+
+  const skyflow = Skyflow.init({
+    vaultID: '<VAULT_ID>',
+    vaultURL: '<VAULT_URL>',
+    getBearerToken: () => {
+      return new Promise((resolve, reject) => {
+        const Http = new XMLHttpRequest();
+
+        Http.onreadystatechange = () => {
+          if (Http.readyState === 4 && Http.status === 200) {
+            const response = JSON.parse(Http.responseText);
+            resolve(response.accessToken);
+          }
+        };
+        const url = '<TOKEN_END_POINT_URL>';
+        Http.open('GET', url);
+        Http.send();
+      });
+    },
+  });
+
+  // form insert request
+
+  const insertButton = document.getElementById('insertButton');
+  if (insertButton) {
+    insertButton.addEventListener('click', () => {
+      const cardNumberElement = document.getElementById('cardNumber') as HTMLInputElement;
+      const cardCvvElement = document.getElementById('cardCvv') as HTMLInputElement;
+      const cardExpiryElement = document.getElementById('cardExpiry') as HTMLInputElement;
+      const cardholderNameElement = document.getElementById('cardHolderName') as HTMLInputElement;
+
+      if (!cardNumberElement || !cardCvvElement || !cardExpiryElement || !cardholderNameElement) {
+        console.error('Required form elements not found');
+        return;
+      }
+
+      const cardNumberData = cardNumberElement.value;
+      const cardCvvData = cardCvvElement.value;
+      const cardExpiryData = cardExpiryElement.value;
+      const cardholderNameData = cardholderNameElement.value;
+
+      const response: Promise<InsertResponse> = skyflow.insert({
+        records: [
+          {
+            fields: {
+              primary_card: {
+                cvv: cardCvvData,
+                card_number: cardNumberData,
+                expiry_date: cardExpiryData,
+              },
+              first_name: cardholderNameData,
+
+            },
+            table: 'pii_fields',
+          },
+        ],
+      });
+
+      response
+        .then(
+          (res: InsertResponse) => {
+            if (revealView) {
+              revealView.style.visibility = 'visible';
+            }
+            const insertResponseElement = document.getElementById('insertResponse');
+            if (insertResponseElement) {
+              insertResponseElement.innerHTML = JSON.stringify(res, null, 2);
+            }
+
+            const fieldsTokenData = res.records[0].fields;
+
+            // Fill tokens.
+            const revealCardNumberElement = document.getElementById('card_number');
+            if (revealCardNumberElement) {
+              revealCardNumberElement.innerText = fieldsTokenData.primary_card.card_number;
+              revealCardNumberElement.setAttribute('id', fieldsTokenData.primary_card.card_number);
+            }
+
+            const revealCardCvvElement = document.getElementById('cvv');
+            if (revealCardCvvElement) {
+              revealCardCvvElement.innerText = fieldsTokenData.primary_card.cvv;
+              revealCardCvvElement.setAttribute('id', fieldsTokenData.primary_card.cvv);
+            }
+
+            const revealExpiryDateElement = document.getElementById('expiry_date');
+            if (revealExpiryDateElement) {
+              revealExpiryDateElement.innerText = fieldsTokenData.primary_card.expiry_date;
+              revealExpiryDateElement.setAttribute('id', fieldsTokenData.primary_card.expiry_date);
+            }
+
+            const revealFirstNameElement = document.getElementById('first_name');
+            if (revealFirstNameElement) {
+              revealFirstNameElement.innerText = fieldsTokenData.first_name;
+              revealFirstNameElement.setAttribute('id', fieldsTokenData.first_name);
+            }
+
+            const revealButton = document.getElementById('revealButton');
+            if (revealButton) {
+              revealButton.addEventListener('click', () => {
+                const revealResult: Promise<DetokenizeResponse> = skyflow.detokenize({
+                  records: [
+                    {
+                      token: fieldsTokenData.primary_card.card_number,
+                      redaction: Skyflow.RedactionType.MASKED
+                    },
+                    {
+                      token: fieldsTokenData.primary_card.cvv,
+                      redaction: Skyflow.RedactionType.REDACTED
+                    },
+                    {
+                      token: fieldsTokenData.primary_card.expiry_date,
+                    },
+                    {
+                      token: fieldsTokenData.first_name,
+                    },
+                  ],
+                });
+                revealResult
+                  .then((res: DetokenizeResponse) => {
+                    const revealResponseElement = document.getElementById('revealResponse');
+                    if (revealResponseElement) {
+                      revealResponseElement.innerHTML = JSON.stringify(res, null, 2);
+                    }
+                    res.records.map((record) => {
+                      const recordKey = record['token'];
+                      const ele = document.getElementById(recordKey);
+                      if (ele) {
+                        ele.innerText = record['value'];
+                      }
+                    });
+                  })
+                  .catch((err) => {
+                    const revealResponseElement = document.getElementById('revealResponse');
+                    if (revealResponseElement) {
+                      revealResponseElement.innerHTML = JSON.stringify(err, null, 2);
+                    }
+                    console.log(err);
+                  });
+              });
+            }
+          },
+          (err) => {
+            const element = document.getElementById('insertResponse');
+            if (element) {
+              element.innerHTML = JSON.stringify(err, null, 2);
+            }
+          }
+        )
+        .catch((err) => {
+          const element = document.getElementById('insertResponse');
+          if (element) {
+            element.innerHTML = JSON.stringify(err, null, 2);
+          }
+        });
+    });
+  }
+} catch (err) {
+  console.error(err);
+}

--- a/samples/using-typescript/pure-js/src/index.ts
+++ b/samples/using-typescript/pure-js/src/index.ts
@@ -39,7 +39,7 @@ try {
   const skyflow = Skyflow.init(config);
 
   // form insert request
-  const insertButton = document.getElementById('insertButton');
+  const insertButton = document.getElementById('insertButton') as HTMLElement;
   if (insertButton) {
     insertButton.addEventListener('click', () => {
       const cardNumberElement = document.getElementById('cardNumber') as HTMLInputElement;
@@ -52,10 +52,10 @@ try {
         return;
       }
 
-      const cardNumberData = cardNumberElement.value;
-      const cardCvvData = cardCvvElement.value;
-      const cardExpiryData = cardExpiryElement.value;
-      const cardholderNameData = cardholderNameElement.value;
+      const cardNumberData: string = cardNumberElement.value;
+      const cardCvvData: string = cardCvvElement.value;
+      const cardExpiryData: string = cardExpiryElement.value;
+      const cardholderNameData: string = cardholderNameElement.value;
 
       const insertRecords: Array<IInsertRecord> = [
         {
@@ -90,25 +90,25 @@ try {
             const fieldsTokenData = res.records[0].fields;
 
             // Fill tokens.
-            const revealCardNumberElement = document.getElementById('card_number');
+            const revealCardNumberElement = document.getElementById('card_number') as HTMLElement;
             if (revealCardNumberElement) {
               revealCardNumberElement.innerText = fieldsTokenData.primary_card.card_number;
               revealCardNumberElement.setAttribute('id', fieldsTokenData.primary_card.card_number);
             }
 
-            const revealCardCvvElement = document.getElementById('cvv');
+            const revealCardCvvElement = document.getElementById('cvv') as HTMLElement;
             if (revealCardCvvElement) {
               revealCardCvvElement.innerText = fieldsTokenData.primary_card.cvv;
               revealCardCvvElement.setAttribute('id', fieldsTokenData.primary_card.cvv);
             }
 
-            const revealExpiryDateElement = document.getElementById('expiry_date');
+            const revealExpiryDateElement = document.getElementById('expiry_date') as HTMLElement;
             if (revealExpiryDateElement) {
               revealExpiryDateElement.innerText = fieldsTokenData.primary_card.expiry_date;
               revealExpiryDateElement.setAttribute('id', fieldsTokenData.primary_card.expiry_date);
             }
 
-            const revealFirstNameElement = document.getElementById('first_name');
+            const revealFirstNameElement = document.getElementById('first_name') as HTMLElement;
             if (revealFirstNameElement) {
               revealFirstNameElement.innerText = fieldsTokenData.first_name;
               revealFirstNameElement.setAttribute('id', fieldsTokenData.first_name);

--- a/samples/using-typescript/skyflow-elements-input-formatting/package.json
+++ b/samples/using-typescript/skyflow-elements-input-formatting/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "skyflowelements",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "start": "parcel src/index.html --open",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "license": "ISC",
+  "dependencies": {
+    "skyflow-js": "^2.3.1"
+  },
+  "devDependencies": {
+    "parcel": "^2.0.1"
+  }
+}

--- a/samples/using-typescript/skyflow-elements-input-formatting/src/collect-input-formatting.ts
+++ b/samples/using-typescript/skyflow-elements-input-formatting/src/collect-input-formatting.ts
@@ -38,7 +38,7 @@ try {
       env: Skyflow.Env.PROD,
     }
   }
-  const skyflow = Skyflow.init(config);
+  const skyflow: Skyflow = Skyflow.init(config);
 
   // Create collect Container.
   const collectContainer = skyflow.container(Skyflow.ContainerType.COLLECT) as CollectContainer;

--- a/samples/using-typescript/skyflow-elements-input-formatting/src/collect-input-formatting.ts
+++ b/samples/using-typescript/skyflow-elements-input-formatting/src/collect-input-formatting.ts
@@ -1,0 +1,151 @@
+/*
+  Copyright (c) 2025 Skyflow, Inc.
+*/
+import Skyflow, {
+  CollectContainer, 
+  CollectElement,
+  CollectResponse,
+} from "skyflow-js";
+
+try {
+
+  const skyflow = Skyflow.init({
+    vaultID: '<VAULT_ID>',
+    vaultURL: '<VAULT_URL>',
+    getBearerToken: () => {
+      return new Promise((resolve, reject) => {
+        const Http = new XMLHttpRequest();
+
+        Http.onreadystatechange = () => {
+          if (Http.readyState === 4 && Http.status === 200) {
+            const response = JSON.parse(Http.responseText);
+            resolve(response.accessToken);
+          }
+        };
+        const url = '<TOKEN_END_POINT_URL>';
+        Http.open('GET', url);
+        Http.send();
+      });
+    },
+    options: {
+      logLevel: Skyflow.LogLevel.ERROR,
+      env: Skyflow.Env.PROD,
+    }
+  });
+
+  // Create collect Container.
+  const collectContainer = skyflow.container(Skyflow.ContainerType.COLLECT) as CollectContainer;
+
+  // Custom styles for collect elements.
+  const collectStylesOptions = {
+    inputStyles: {
+      base: {
+        border: '1px solid #eae8ee',
+        padding: '10px 16px',
+        borderRadius: '4px',
+        color: '#1d1d1d',
+        marginTop: '4px',
+      },
+      complete: {
+        color: '#4caf50',
+      },
+      empty: {},
+      focus: {},
+      invalid: {
+        color: '#f44336',
+      },
+    },
+    labelStyles: {
+      base: {
+        fontSize: '16px',
+        fontWeight: 'bold',
+      },
+    },
+    errorTextStyles: {
+      base: {
+        color: '#f44336',
+      },
+    },
+  };
+
+  // Create collect elements.
+  const cardNumberElement: CollectElement = collectContainer.create({
+    table: 'pii_fields',
+    column: 'primary_card.card_number',
+    ...collectStylesOptions,
+    placeholder: 'card number',
+    label: 'Card Number',
+    type: Skyflow.ElementType.CARD_NUMBER,
+  }, {
+    format: 'XXXX-XXXX-XXXX-XXXX' // inbuilt format
+  });
+
+  const ssnElement: CollectElement = collectContainer.create({
+    table: 'pii_fields',
+    column: 'ssn',
+    ...collectStylesOptions,
+    label: 'SSN',
+    placeholder: 'ssn',
+    type: Skyflow.ElementType.INPUT_FIELD,
+  }, {
+    format: 'XXX-XX-XXXX',
+    translation: { X: '[0-9]' } // translates each 'X' in format string accepts a digit ranging from 0-9.
+  });
+
+  const expiryDateElement: CollectElement = collectContainer.create({
+    table: 'pii_fields',
+    column: 'primary_card.expiry_date',
+    ...collectStylesOptions,
+    label: 'Expiry Date',
+    placeholder: 'MM/YYYY',
+    type: Skyflow.ElementType.EXPIRATION_DATE,
+  }, {
+    format: 'MM/YYYY' // inbuilt format.
+  });
+
+  const passportNumberElement: CollectElement = collectContainer.create({
+    table: 'pii_fields',
+    column: 'passport_number',
+    ...collectStylesOptions,
+    label: 'Passport Number',
+    placeholder: 'passport number',
+    type: Skyflow.ElementType.INPUT_FIELD,
+  }, {
+    format: 'XXYYYYYYY',
+    translation: { X: '[A-Z]', Y: '[0-9]' }
+    // translates each 'X' in format string accepts a uppercase alphabet A to Z.
+    // and each 'Y' in format string accepts a digit ranging from 0-9.
+  });
+
+  // Mount the elements.
+  cardNumberElement.mount('#collectCardNumber');
+  ssnElement.mount('#collectCvv');
+  expiryDateElement.mount('#collectExpiryDate');
+  passportNumberElement.mount('#collectCardholderName');
+
+  // Collect all elements data.
+  const collectButton = document.getElementById('collectPCIData');
+  if (collectButton) {
+    collectButton.addEventListener('click', () => {
+      const collectResponse: Promise<CollectResponse> = collectContainer.collect();
+      collectResponse
+        .then((response) => {
+          console.log(response);
+          response = response;
+          const responseElement = document.getElementById('collectResponse');
+          if (responseElement) {
+            responseElement.innerHTML = JSON.stringify(response, null, 2);
+          }
+        })
+        .catch((err) => {
+          const errorElement = document.getElementById('collectResponse');
+          if (errorElement){
+            errorElement.innerHTML = JSON.stringify(err, null, 2);
+          }
+          console.log(err);
+        });
+    });
+  }
+} catch (err) {
+  console.log(err);
+}

--- a/samples/using-typescript/skyflow-elements-input-formatting/src/collect-input-formatting.ts
+++ b/samples/using-typescript/skyflow-elements-input-formatting/src/collect-input-formatting.ts
@@ -4,12 +4,18 @@
 import Skyflow, {
   CollectContainer, 
   CollectElement,
+  CollectElementInput,
+  CollectElementOptions,
   CollectResponse,
+  ErrorTextStyles,
+  InputStyles,
+  ISkyflow,  
+  LabelStyles,
 } from "skyflow-js";
 
 try {
 
-  const skyflow = Skyflow.init({
+  const config: ISkyflow = {
     vaultID: '<VAULT_ID>',
     vaultURL: '<VAULT_URL>',
     getBearerToken: () => {
@@ -31,7 +37,8 @@ try {
       logLevel: Skyflow.LogLevel.ERROR,
       env: Skyflow.Env.PROD,
     }
-  });
+  }
+  const skyflow = Skyflow.init(config);
 
   // Create collect Container.
   const collectContainer = skyflow.container(Skyflow.ContainerType.COLLECT) as CollectContainer;
@@ -54,68 +61,85 @@ try {
       invalid: {
         color: '#f44336',
       },
-    },
+    } as InputStyles,
     labelStyles: {
       base: {
         fontSize: '16px',
         fontWeight: 'bold',
       },
-    },
+    } as LabelStyles,
     errorTextStyles: {
       base: {
         color: '#f44336',
       },
-    },
+    } as ErrorTextStyles,
   };
 
   // Create collect elements.
-  const cardNumberElement: CollectElement = collectContainer.create({
+  const cardNumberInput: CollectElementInput = {
     table: 'pii_fields',
     column: 'primary_card.card_number',
     ...collectStylesOptions,
     placeholder: 'card number',
     label: 'Card Number',
     type: Skyflow.ElementType.CARD_NUMBER,
-  }, {
+  };
+  const cardNumberOptions: CollectElementOptions = {
     format: 'XXXX-XXXX-XXXX-XXXX' // inbuilt format
-  });
+  };
+  const cardNumberElement: CollectElement = collectContainer.create(
+    cardNumberInput, 
+    cardNumberOptions
+  );
 
-  const ssnElement: CollectElement = collectContainer.create({
+  const ssnInput: CollectElementInput = {
     table: 'pii_fields',
     column: 'ssn',
     ...collectStylesOptions,
     label: 'SSN',
     placeholder: 'ssn',
     type: Skyflow.ElementType.INPUT_FIELD,
-  }, {
+  };
+  const ssnOptions: CollectElementOptions = {
     format: 'XXX-XX-XXXX',
     translation: { X: '[0-9]' } // translates each 'X' in format string accepts a digit ranging from 0-9.
-  });
+  };
+  const ssnElement: CollectElement = collectContainer.create(ssnInput, ssnOptions);
 
-  const expiryDateElement: CollectElement = collectContainer.create({
+  const expiryDateInput: CollectElementInput = {
     table: 'pii_fields',
     column: 'primary_card.expiry_date',
     ...collectStylesOptions,
     label: 'Expiry Date',
     placeholder: 'MM/YYYY',
     type: Skyflow.ElementType.EXPIRATION_DATE,
-  }, {
+  };
+  const ExpiryDateOptions: CollectElementOptions =  {
     format: 'MM/YYYY' // inbuilt format.
-  });
+  };
+  const expiryDateElement: CollectElement = collectContainer.create(
+    expiryDateInput,
+    ExpiryDateOptions,
+  );
 
-  const passportNumberElement: CollectElement = collectContainer.create({
+  const passportNumberInput: CollectElementInput = {
     table: 'pii_fields',
     column: 'passport_number',
     ...collectStylesOptions,
     label: 'Passport Number',
     placeholder: 'passport number',
     type: Skyflow.ElementType.INPUT_FIELD,
-  }, {
+  };
+  const passportNumberOptions: CollectElementOptions = {
     format: 'XXYYYYYYY',
     translation: { X: '[A-Z]', Y: '[0-9]' }
     // translates each 'X' in format string accepts a uppercase alphabet A to Z.
     // and each 'Y' in format string accepts a digit ranging from 0-9.
-  });
+  };
+  const passportNumberElement: CollectElement = collectContainer.create(
+    passportNumberInput,
+    passportNumberOptions,
+  );
 
   // Mount the elements.
   cardNumberElement.mount('#collectCardNumber');
@@ -129,7 +153,7 @@ try {
     collectButton.addEventListener('click', () => {
       const collectResponse: Promise<CollectResponse> = collectContainer.collect();
       collectResponse
-        .then((response) => {
+        .then((response: CollectResponse) => {
           console.log(response);
           response = response;
           const responseElement = document.getElementById('collectResponse');
@@ -137,7 +161,7 @@ try {
             responseElement.innerHTML = JSON.stringify(response, null, 2);
           }
         })
-        .catch((err) => {
+        .catch((err: CollectResponse) => {
           const errorElement = document.getElementById('collectResponse');
           if (errorElement){
             errorElement.innerHTML = JSON.stringify(err, null, 2);
@@ -146,6 +170,6 @@ try {
         });
     });
   }
-} catch (err) {
+} catch (err: unknown) {
   console.log(err);
 }

--- a/samples/using-typescript/skyflow-elements-input-formatting/src/index.html
+++ b/samples/using-typescript/skyflow-elements-input-formatting/src/index.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Skyflow Elements</title>
+    <style>
+      body {
+        display: flex;
+        flex-direction: column;
+      }
+      .empty-div {
+        height: 100px;
+        width: 350px;
+      }
+      .reveal-view {
+        margin-top: 48px;
+      }
+    </style>
+  </head>
+  <body>
+    <h3>Collect Elements</h3>
+    <!-- COllect Part -->
+    <div>
+      <div id="collectCardNumber" class="empty-div"></div>
+      <div id="collectCvv" class="empty-div"></div>
+      <div id="collectExpiryDate" class="empty-div"></div>
+      <div id="collectCardholderName" class="empty-div"></div>
+      <div>
+        <button id="collectPCIData">Collect Data</button>
+      </div>
+      <div>
+        <pre id="collectResponse"></pre>
+      </div>
+    </div>
+    <!-- Reveal Part-->
+    <div id="revealView" class="reveal-view">
+      <h3>Reveal Elements</h3>
+      <div id="revealCardNumber" class="empty-div"></div>
+      <div id="revealCvv" class="empty-div"></div>
+      <div id="revealExpiryDate" class="empty-div"></div>
+      <div id="revealCardholderName" class="empty-div"></div>
+      <div>
+        <button id="revealPCIData">Reveal Data</button>
+      </div>
+    </div>
+    
+    <script type="module" src="collect-input-formatting.js"></script>
+    <script type="module" src="reveal-input-formatting.js"></script>
+  </body>
+</html>

--- a/samples/using-typescript/skyflow-elements-input-formatting/src/reveal-input-formatting.ts
+++ b/samples/using-typescript/skyflow-elements-input-formatting/src/reveal-input-formatting.ts
@@ -37,8 +37,7 @@ try {
       env: Skyflow.Env.PROD,
     }
   }
-  const skyflow = Skyflow.init(config);
-
+  const skyflow: Skyflow = Skyflow.init(config);
 
   const revealStyleOptions = {
     inputStyles: {

--- a/samples/using-typescript/skyflow-elements-input-formatting/src/reveal-input-formatting.ts
+++ b/samples/using-typescript/skyflow-elements-input-formatting/src/reveal-input-formatting.ts
@@ -2,13 +2,19 @@
   Copyright (c) 2025 Skyflow, Inc.
 */
 import Skyflow, {
+  ErrorTextStyles,
+  InputStyles,
+  IRevealElementOptions,
+  IRevealElementInput,
+  ISkyflow,
+  LabelStyles,
   RevealContainer, 
   RevealElement,
   RevealResponse,
 } from "skyflow-js";
 
 try {
-  const skyflow = Skyflow.init({
+  const config: ISkyflow = {
     vaultID: '<VAULT_ID>',
     vaultURL: '<VAULT_URL>',
     getBearerToken: () => {
@@ -30,7 +36,8 @@ try {
       logLevel: Skyflow.LogLevel.ERROR,
       env: Skyflow.Env.PROD,
     }
-  });
+  }
+  const skyflow = Skyflow.init(config);
 
 
   const revealStyleOptions = {
@@ -42,59 +49,79 @@ try {
         color: '#1d1d1d',
         marginTop: '4px',
       },
-    },
+    } as InputStyles,
     labelStyles: {
       base: {
         fontSize: '16px',
         fontWeight: 'bold',
       },
-    },
+    } as LabelStyles,
     errorTextStyles: {
       base: {
         color: '#f44336',
       },
-    },
+    } as ErrorTextStyles,
   };
 
   const revealContainer = skyflow.container(Skyflow.ContainerType.REVEAL) as RevealContainer;
-  const revealCardNumberElement: RevealElement = revealContainer.create({
+  const revealCardNumberInput: IRevealElementInput = {
     token: '<TOKEN 1>',
     label: 'Card Number',
     ...revealStyleOptions,
-  }, {
+  };
+  const revealCardNumberOptions: IRevealElementOptions = {
     format: 'XXXX-XXXX-XXXX-XXXX',
     translation: { X: '[0-9]' }
-  });
+  };
+  const revealCardNumberElement: RevealElement = revealContainer.create(
+    revealCardNumberInput,
+    revealCardNumberOptions,
+  );
   revealCardNumberElement.mount('#revealCardNumber');
 
-  const revealSSNElement: RevealElement = revealContainer.create({
+  const revealSSNInput: IRevealElementInput = {
     token: '<TOKEN 2>',
     label: 'SSN',
     ...revealStyleOptions,
     altText: '###',
-  }, {
+  };
+  const revealSSNOptions: IRevealElementOptions = {
     format: 'XX-XXX-XXXX',
-  });
+  };
+  const revealSSNElement: RevealElement = revealContainer.create(
+    revealSSNInput,
+    revealSSNOptions
+  );
   revealSSNElement.mount('#revealCvv');
 
-  const revealPhoneNumberElement: RevealElement = revealContainer.create({
+  const revealPhoneNumberInput: IRevealElementInput = {
     token: '<TOKEN 3>',
     label: 'Phone Number',
     ...revealStyleOptions,
-  }, {
+  }
+  const revealPhoneNumberOptions: IRevealElementOptions = {
     format: '(XXX) XXX-XXXX',
     translation: { X: '[0-9]' }
-  });
+  }
+  const revealPhoneNumberElement: RevealElement = revealContainer.create(
+    revealPhoneNumberInput,
+    revealPhoneNumberOptions,
+  );
   revealPhoneNumberElement.mount('#revealExpiryDate');
 
-  const revealDrivingLicenseElement: RevealElement = revealContainer.create({
+  const revealDrivingLicenseInput: IRevealElementInput = {
     token: '<TOKEN 4>',
     label: 'Driving License',
     ...revealStyleOptions,
-  }, {
+  };
+  const revealDrivingLicenseOptions: IRevealElementOptions = {
     format: 'YXX XXXX XXXX',
     translation: { Y: '[A-Z]', X: '[0-9]' }
-  });
+  }
+  const revealDrivingLicenseElement: RevealElement = revealContainer.create(
+    revealDrivingLicenseInput,
+    revealDrivingLicenseOptions
+  );
   revealDrivingLicenseElement.mount('#revealCardholderName');
 
   const revealButton = document.getElementById('revealPCIData');
@@ -102,13 +129,13 @@ try {
   if (revealButton) {
     revealButton.addEventListener('click', () => {
       const revealResponse: Promise<RevealResponse> = revealContainer.reveal()
-      revealResponse.then((res) => {
+      revealResponse.then((res: RevealResponse) => {
         console.log(res);
-      }).catch((err) => {
+      }).catch((err: RevealResponse) => {
         console.log(err);
       });
     });
   }
-} catch (err) {
+} catch (err: unknown) {
   console.log(err);
 }

--- a/samples/using-typescript/skyflow-elements-input-formatting/src/reveal-input-formatting.ts
+++ b/samples/using-typescript/skyflow-elements-input-formatting/src/reveal-input-formatting.ts
@@ -1,0 +1,114 @@
+/*
+  Copyright (c) 2025 Skyflow, Inc.
+*/
+import Skyflow, {
+  RevealContainer, 
+  RevealElement,
+  RevealResponse,
+} from "skyflow-js";
+
+try {
+  const skyflow = Skyflow.init({
+    vaultID: '<VAULT_ID>',
+    vaultURL: '<VAULT_URL>',
+    getBearerToken: () => {
+      return new Promise((resolve, reject) => {
+        const Http = new XMLHttpRequest();
+
+        Http.onreadystatechange = () => {
+          if (Http.readyState === 4 && Http.status === 200) {
+            const response = JSON.parse(Http.responseText);
+            resolve(response.accessToken);
+          }
+        };
+        const url = '<TOKEN_END_POINT_URL>';
+        Http.open('GET', url);
+        Http.send();
+      });
+    },
+    options: {
+      logLevel: Skyflow.LogLevel.ERROR,
+      env: Skyflow.Env.PROD,
+    }
+  });
+
+
+  const revealStyleOptions = {
+    inputStyles: {
+      base: {
+        border: '1px solid #eae8ee',
+        padding: '10px 16px',
+        borderRadius: '4px',
+        color: '#1d1d1d',
+        marginTop: '4px',
+      },
+    },
+    labelStyles: {
+      base: {
+        fontSize: '16px',
+        fontWeight: 'bold',
+      },
+    },
+    errorTextStyles: {
+      base: {
+        color: '#f44336',
+      },
+    },
+  };
+
+  const revealContainer = skyflow.container(Skyflow.ContainerType.REVEAL) as RevealContainer;
+  const revealCardNumberElement: RevealElement = revealContainer.create({
+    token: '<TOKEN 1>',
+    label: 'Card Number',
+    ...revealStyleOptions,
+  }, {
+    format: 'XXXX-XXXX-XXXX-XXXX',
+    translation: { X: '[0-9]' }
+  });
+  revealCardNumberElement.mount('#revealCardNumber');
+
+  const revealSSNElement: RevealElement = revealContainer.create({
+    token: '<TOKEN 2>',
+    label: 'SSN',
+    ...revealStyleOptions,
+    altText: '###',
+  }, {
+    format: 'XX-XXX-XXXX',
+  });
+  revealSSNElement.mount('#revealCvv');
+
+  const revealPhoneNumberElement: RevealElement = revealContainer.create({
+    token: '<TOKEN 3>',
+    label: 'Phone Number',
+    ...revealStyleOptions,
+  }, {
+    format: '(XXX) XXX-XXXX',
+    translation: { X: '[0-9]' }
+  });
+  revealPhoneNumberElement.mount('#revealExpiryDate');
+
+  const revealDrivingLicenseElement: RevealElement = revealContainer.create({
+    token: '<TOKEN 4>',
+    label: 'Driving License',
+    ...revealStyleOptions,
+  }, {
+    format: 'YXX XXXX XXXX',
+    translation: { Y: '[A-Z]', X: '[0-9]' }
+  });
+  revealDrivingLicenseElement.mount('#revealCardholderName');
+
+  const revealButton = document.getElementById('revealPCIData');
+
+  if (revealButton) {
+    revealButton.addEventListener('click', () => {
+      const revealResponse: Promise<RevealResponse> = revealContainer.reveal()
+      revealResponse.then((res) => {
+        console.log(res);
+      }).catch((err) => {
+        console.log(err);
+      });
+    });
+  }
+} catch (err) {
+  console.log(err);
+}

--- a/samples/using-typescript/skyflow-elements-update-records/package.json
+++ b/samples/using-typescript/skyflow-elements-update-records/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "skyflow-elements-update-records",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "start": "parcel src/index.html --open",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "license": "ISC",
+  "dependencies": {
+    "skyflow-js": "^2.3.1"
+  },
+  "devDependencies": {
+    "parcel": "^2.0.1"
+  }
+}

--- a/samples/using-typescript/skyflow-elements-update-records/src/index.html
+++ b/samples/using-typescript/skyflow-elements-update-records/src/index.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Skyflow Elements</title>
+    <style>
+      body {
+        display: flex;
+        flex-direction: column;
+      }
+      .empty-div {
+        height: 100px;
+        width: 350px;
+      }
+    </style>
+  </head>
+  <body>
+    <h3>Collect Elements</h3>
+    <!-- COllect Part -->
+    <div>
+      <div id="collectCardNumber" class="empty-div"></div>
+      <div id="collectCvv" class="empty-div"></div>
+      <div id="collectExpiryDate" class="empty-div"></div>
+      <div id="collectCardholderName" class="empty-div"></div>
+      <div>
+        <button id="collectPCIData">Collect PCI Data</button>
+      </div>
+      <div>
+        <pre id="collectResponse"></pre>
+      </div>
+    </div>      
+    <script type="module" src="index.js"></script>
+  </body>
+</html>

--- a/samples/using-typescript/skyflow-elements-update-records/src/index.ts
+++ b/samples/using-typescript/skyflow-elements-update-records/src/index.ts
@@ -4,10 +4,18 @@
 import Skyflow, { 
   CollectContainer,
   CollectElement,
+  CollectElementInput,
   CollectResponse,
+  ErrorTextStyles,
+  ICollectOptions,
+  IInsertRecordInput,
+  IInsertRecord,
+  InputStyles,
+  ISkyflow,
+  LabelStyles,
 } from 'skyflow-js';
 try {
-  const skyflow = Skyflow.init({
+  const config: ISkyflow = {
     vaultID: '<VAULT_ID>',
     vaultURL: '<VAULT_URL>',
     getBearerToken: () => {
@@ -29,7 +37,8 @@ try {
       logLevel: Skyflow.LogLevel.ERROR,
       env: Skyflow.Env.PROD,
     },
-  });
+  }
+  const skyflow = Skyflow.init(config);
   // Create collect Container.
   const collectContainer = skyflow.container(Skyflow.ContainerType.COLLECT) as CollectContainer;
 
@@ -51,22 +60,22 @@ try {
       invalid: {
         color: '#f44336',
       },
-    },
+    } as InputStyles,
     labelStyles: {
       base: {
         fontSize: '16px',
         fontWeight: 'bold',
       },
-    },
+    } as LabelStyles,
     errorTextStyles: {
       base: {
         color: '#f44336',
       },
-    },
+    } as ErrorTextStyles,
   };
 
   // Create collect elements.
-  const cardNumberElement: CollectElement = collectContainer.create({
+  const cardNumberInput: CollectElementInput = {
     table: 'table1',
     column: 'card_number',
     ...collectStylesOptions,
@@ -74,9 +83,10 @@ try {
     label: 'Card Number',
     skyflowID: '',
     type: Skyflow.ElementType.CARD_NUMBER,
-  });
+  };
+  const cardNumberElement: CollectElement = collectContainer.create(cardNumberInput);
 
-  const cvvElement: CollectElement = collectContainer.create({
+  const cvvInput: CollectElementInput = {
     table: 'table1',
     column: 'cvv',
     ...collectStylesOptions,
@@ -84,9 +94,10 @@ try {
     placeholder: 'cvv',
     type: Skyflow.ElementType.CVV,
     skyflowID: '',
-  });
+  };
+  const cvvElement: CollectElement = collectContainer.create(cvvInput);
 
-  const expiryDateElement: CollectElement = collectContainer.create({
+  const expiryDateInput: CollectElementInput = {
     table: 'table1',
     column: 'expiry_date',
     ...collectStylesOptions,
@@ -94,16 +105,18 @@ try {
     placeholder: 'MM/YYYY',
     type: Skyflow.ElementType.EXPIRATION_DATE,
     skyflowID: '',
-  });
+  };
+  const expiryDateElement: CollectElement = collectContainer.create(expiryDateInput);
 
-  const cardHolderNameElement: CollectElement = collectContainer.create({
+  const cardHolderNameInput: CollectElementInput = {
     table: 'table2',
     column: 'name',
     ...collectStylesOptions,
     label: 'Card Holder Name',
     placeholder: 'cardholder name',
     type: Skyflow.ElementType.CARDHOLDER_NAME,
-  });
+  };
+  const cardHolderNameElement: CollectElement = collectContainer.create(cardHolderNameInput);
 
   // Mount the elements.
   cardNumberElement.mount('#collectCardNumber');
@@ -113,38 +126,40 @@ try {
 
   // Collect all elements data.
   const collectButton = document.getElementById('collectPCIData');
-  const records = {
-    tokens: true,
-    additionalFields: {
-      records: [
-        {
-          table: 'table1',
-          fields: {
-            skyflowID: '',
-            gender: 'MALE',
-          },
-        },
-        {
-          table: 'table2',
-          fields: {
-            gender: 'MALE',
-          },
-        },
-      ],
+  const records: Array<IInsertRecord> = [
+    {
+      table: 'table1',
+      fields: {
+        skyflowID: '',
+        gender: 'MALE',
+      },
     },
+    {
+      table: 'table2',
+      fields: {
+        gender: 'MALE',
+      },
+    },
+  ];
+  const additionalFields: IInsertRecordInput = {
+    records: records,
+  };
+  const collectOptions: ICollectOptions = {
+    tokens: true,
+    additionalFields: additionalFields,
   };
   if (collectButton) {
     collectButton.addEventListener('click', () => {
-      const collectResponse: Promise<CollectResponse> = collectContainer.collect(records);
+      const collectResponse: Promise<CollectResponse> = collectContainer.collect(collectOptions);
       collectResponse
-        .then((response) => {
+        .then((response: CollectResponse) => {
           console.log(response);
           const responseElement = document.getElementById('collectResponse');
           if (responseElement) {
             responseElement.innerHTML = JSON.stringify(response, null, 2);
           }
         })
-        .catch((err) => {
+        .catch((err: CollectResponse) => {
           const errorElement = document.getElementById('collectResponse');
           if (errorElement){
             errorElement.innerHTML = JSON.stringify(err, null, 2);
@@ -153,6 +168,6 @@ try {
         });
     });
   }
-} catch (err) {
+} catch (err: unknown) {
   console.log(err);
 }

--- a/samples/using-typescript/skyflow-elements-update-records/src/index.ts
+++ b/samples/using-typescript/skyflow-elements-update-records/src/index.ts
@@ -38,7 +38,7 @@ try {
       env: Skyflow.Env.PROD,
     },
   }
-  const skyflow = Skyflow.init(config);
+  const skyflow: Skyflow = Skyflow.init(config);
   // Create collect Container.
   const collectContainer = skyflow.container(Skyflow.ContainerType.COLLECT) as CollectContainer;
 

--- a/samples/using-typescript/skyflow-elements-update-records/src/index.ts
+++ b/samples/using-typescript/skyflow-elements-update-records/src/index.ts
@@ -1,0 +1,158 @@
+/*
+  Copyright (c) 2025 Skyflow, Inc.
+*/
+import Skyflow, { 
+  CollectContainer,
+  CollectElement,
+  CollectResponse,
+} from 'skyflow-js';
+try {
+  const skyflow = Skyflow.init({
+    vaultID: '<VAULT_ID>',
+    vaultURL: '<VAULT_URL>',
+    getBearerToken: () => {
+      return new Promise((resolve, reject) => {
+        const Http = new XMLHttpRequest();
+
+        Http.onreadystatechange = () => {
+          if (Http.readyState === 4 && Http.status === 200) {
+            const response = JSON.parse(Http.responseText);
+            resolve(response.accessToken);
+          }
+        };
+        const url = '<TOKEN_END_POINT_URL>';
+        Http.open('GET', url);
+        Http.send();
+      });
+    },
+    options: {
+      logLevel: Skyflow.LogLevel.ERROR,
+      env: Skyflow.Env.PROD,
+    },
+  });
+  // Create collect Container.
+  const collectContainer = skyflow.container(Skyflow.ContainerType.COLLECT) as CollectContainer;
+
+  // Custom styles for collect elements.
+  const collectStylesOptions = {
+    inputStyles: {
+      base: {
+        border: '1px solid #eae8ee',
+        padding: '10px 16px',
+        borderRadius: '4px',
+        color: '#1d1d1d',
+        marginTop: '4px',
+      },
+      complete: {
+        color: '#4caf50',
+      },
+      empty: {},
+      focus: {},
+      invalid: {
+        color: '#f44336',
+      },
+    },
+    labelStyles: {
+      base: {
+        fontSize: '16px',
+        fontWeight: 'bold',
+      },
+    },
+    errorTextStyles: {
+      base: {
+        color: '#f44336',
+      },
+    },
+  };
+
+  // Create collect elements.
+  const cardNumberElement: CollectElement = collectContainer.create({
+    table: 'table1',
+    column: 'card_number',
+    ...collectStylesOptions,
+    placeholder: 'card number',
+    label: 'Card Number',
+    skyflowID: '',
+    type: Skyflow.ElementType.CARD_NUMBER,
+  });
+
+  const cvvElement: CollectElement = collectContainer.create({
+    table: 'table1',
+    column: 'cvv',
+    ...collectStylesOptions,
+    label: 'Cvv',
+    placeholder: 'cvv',
+    type: Skyflow.ElementType.CVV,
+    skyflowID: '',
+  });
+
+  const expiryDateElement: CollectElement = collectContainer.create({
+    table: 'table1',
+    column: 'expiry_date',
+    ...collectStylesOptions,
+    label: 'Expiry Date',
+    placeholder: 'MM/YYYY',
+    type: Skyflow.ElementType.EXPIRATION_DATE,
+    skyflowID: '',
+  });
+
+  const cardHolderNameElement: CollectElement = collectContainer.create({
+    table: 'table2',
+    column: 'name',
+    ...collectStylesOptions,
+    label: 'Card Holder Name',
+    placeholder: 'cardholder name',
+    type: Skyflow.ElementType.CARDHOLDER_NAME,
+  });
+
+  // Mount the elements.
+  cardNumberElement.mount('#collectCardNumber');
+  cvvElement.mount('#collectCvv');
+  expiryDateElement.mount('#collectExpiryDate');
+  cardHolderNameElement.mount('#collectCardholderName');
+
+  // Collect all elements data.
+  const collectButton = document.getElementById('collectPCIData');
+  const records = {
+    tokens: true,
+    additionalFields: {
+      records: [
+        {
+          table: 'table1',
+          fields: {
+            skyflowID: '',
+            gender: 'MALE',
+          },
+        },
+        {
+          table: 'table2',
+          fields: {
+            gender: 'MALE',
+          },
+        },
+      ],
+    },
+  };
+  if (collectButton) {
+    collectButton.addEventListener('click', () => {
+      const collectResponse: Promise<CollectResponse> = collectContainer.collect(records);
+      collectResponse
+        .then((response) => {
+          console.log(response);
+          const responseElement = document.getElementById('collectResponse');
+          if (responseElement) {
+            responseElement.innerHTML = JSON.stringify(response, null, 2);
+          }
+        })
+        .catch((err) => {
+          const errorElement = document.getElementById('collectResponse');
+          if (errorElement){
+            errorElement.innerHTML = JSON.stringify(err, null, 2);
+          }
+          console.log(err);
+        });
+    });
+  }
+} catch (err) {
+  console.log(err);
+}

--- a/samples/using-typescript/skyflow-elements-update/.gitignore
+++ b/samples/using-typescript/skyflow-elements-update/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+.parcel-cache/
+dist/
+package-lock.json

--- a/samples/using-typescript/skyflow-elements-update/package.json
+++ b/samples/using-typescript/skyflow-elements-update/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "skyflow-elements-update",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "skyflow-js": "^2.3.1"
+  },
+  "devDependencies": {
+    "parcel": "^2.0.1"
+  }
+}

--- a/samples/using-typescript/skyflow-elements-update/src/index.html
+++ b/samples/using-typescript/skyflow-elements-update/src/index.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Skyflow Elements Update</title>
+    <style>
+      body {
+        display: flex;
+        flex-direction: column;
+      }
+      .empty-div {
+        height: 100px;
+        width: 350px;
+      }
+      .reveal-view {
+        margin-top: 48px;
+      }
+    </style>
+  </head>
+  <body>
+    <!-- Collect Part -->
+    <div id="collectView">
+      <h3>Collect Elements</h3>
+      <div id="collectCardNumber" class="empty-div"></div>
+      <div id="collectCvv" class="empty-div"></div>
+      <div id="collectExpiryDate" class="empty-div"></div>
+      <div id="collectCardholderName" class="empty-div"></div>
+      <div>
+        <button id="collectPCIData">Collect PCI Data</button>
+        <button id="updateCollectElements">Update Elements Properties</button>
+      </div>
+      <div>
+        <pre id="collectResponse"></pre>
+      </div>
+    </div>
+    <!-- Reveal Part-->
+    <div id="revealView" class="reveal-view">
+      <h3>Reveal Elements</h3>
+      <div id="revealCardNumber" class="empty-div"></div>
+      <div id="revealCvv" class="empty-div"></div>
+      <div id="revealExpiryDate" class="empty-div"></div>
+      <div id="revealCardholderName" class="empty-div"></div>
+      <div>
+        <button id="revealPCIData">Reveal PCI Data</button>
+        <button id="updateRevealElements">Update Elements Properties</button>
+      </div>
+    </div>
+  </body>
+	<script type="module" src="index.js"></script>
+</html>

--- a/samples/using-typescript/skyflow-elements-update/src/index.ts
+++ b/samples/using-typescript/skyflow-elements-update/src/index.ts
@@ -47,7 +47,7 @@ try {
       env: Skyflow.Env.PROD,
     },
   }
-  const skyflow = Skyflow.init(config);
+  const skyflow: Skyflow = Skyflow.init(config);
 
   // Create collect Container.
   const collectContainer = skyflow.container(Skyflow.ContainerType.COLLECT) as CollectContainer;
@@ -180,7 +180,6 @@ try {
 
   // OnChange listener for cardNumber element.
   cardNumberElement.on(Skyflow.EventName.CHANGE, (state: any) => {
-    console.log("update validation", state);
     if (state.isValid) {
       // update cvv element validation rule.
       if (findCvvLength(state.value) === 3) {

--- a/samples/using-typescript/skyflow-elements-update/src/index.ts
+++ b/samples/using-typescript/skyflow-elements-update/src/index.ts
@@ -1,0 +1,381 @@
+/*
+  Copyright (c) 2025 Skyflow, Inc.
+*/
+import Skyflow, {
+  CollectContainer, 
+  CollectElement,
+  CollectResponse,
+  RevealContainer,
+  RevealElement,
+  RevealResponse,
+} from "skyflow-js";
+
+try {
+  const revealView = document.getElementById("revealView");
+  if (revealView) {
+    revealView.style.visibility = "hidden";
+  }
+  let response;
+  const skyflow = Skyflow.init({
+    vaultID: "<VAULT_ID>",
+    vaultURL: "<VAULT_URL>",
+    getBearerToken: () => {
+      return new Promise((resolve, reject) => {
+        const Http = new XMLHttpRequest();
+
+        Http.onreadystatechange = () => {
+          if (Http.readyState === 4 && Http.status === 200) {
+            const response = JSON.parse(Http.responseText);
+            resolve(response.accessToken);
+          }
+        };
+        const url = "<TOKEN_END_POINT_URL>";
+        Http.open("GET", url);
+        Http.send();
+      });
+    },
+    options: {
+      logLevel: Skyflow.LogLevel.ERROR,
+      env: Skyflow.Env.PROD,
+    },
+  });
+
+  // Create collect Container.
+  const collectContainer = skyflow.container(Skyflow.ContainerType.COLLECT) as CollectContainer;
+
+  // Custom styles for collect elements.
+  const collectStylesOptions = {
+    inputStyles: {
+      base: {
+        border: "1px solid #eae8ee",
+        padding: "10px 16px",
+        borderRadius: "4px",
+        color: "#1d1d1d",
+        marginTop: "4px",
+        fontFamily: '"Roboto", sans-serif',
+      },
+      complete: {
+        color: "#4caf50",
+      },
+      empty: {},
+      focus: {},
+      invalid: {
+        color: "#f44336",
+      },
+      global: {
+        "@import":
+          'url("https://fonts.googleapis.com/css2?family=Roboto&display=swap")',
+      },
+    },
+    labelStyles: {
+      base: {
+        fontSize: "16px",
+        fontWeight: "bold",
+        fontFamily: '"Roboto", sans-serif',
+      },
+      global: {
+        "@import":
+          'url("https://fonts.googleapis.com/css2?family=Roboto&display=swap")',
+      },
+      requiredAsterisk: {
+        color: "red",
+      },
+    },
+    errorTextStyles: {
+      base: {
+        color: "#f44336",
+        fontFamily: '"Roboto", sans-serif',
+      },
+      global: {
+        "@import":
+          'url("https://fonts.googleapis.com/css2?family=Roboto&display=swap")',
+      },
+    },
+  };
+
+  // Create collect elements.
+  const cardNumberElement: CollectElement = collectContainer.create(
+    {
+      table: "pii_fields",
+      column: "card_number",
+      ...collectStylesOptions,
+      placeholder: "card number",
+      label: "Card Number",
+      type: Skyflow.ElementType.CARD_NUMBER,
+    },
+    {
+      required: true,
+    }
+  );
+
+  const cvvElement: CollectElement = collectContainer.create({
+    table: "pii_fields",
+    column: "cvv",
+    ...collectStylesOptions,
+    label: "Cvv",
+    placeholder: "cvv",
+    type: Skyflow.ElementType.CVV,
+  });
+
+  const expiryDateElement: CollectElement = collectContainer.create({
+    table: "pii_fields",
+    column: "primary_card.expiry_date",
+    ...collectStylesOptions,
+    label: "Expiry Date",
+    placeholder: "MM/YYYY",
+    type: Skyflow.ElementType.EXPIRATION_DATE,
+  });
+
+  const cardHolderNameElement: CollectElement = collectContainer.create({
+    table: "pii_fields",
+    column: "name",
+    ...collectStylesOptions,
+    label: "Card Holder Name",
+    placeholder: "cardholder name",
+    type: Skyflow.ElementType.CARDHOLDER_NAME,
+  });
+
+  // Mount the elements.
+  cardNumberElement.mount("#collectCardNumber");
+  cvvElement.mount("#collectCvv");
+  expiryDateElement.mount("#collectExpiryDate");
+  cardHolderNameElement.mount("#collectCardholderName");
+
+  // Sample helper function to determine cvv length.
+  const findCvvLength = (cardBinValue) => {
+    console.log("Came here..!");
+    const amexRegex = /^3[78][0-9]{4}$/;
+    return amexRegex.test(cardBinValue.slice(0, 6)) ? 4 : 3;
+  };
+
+  // Validation rules for cvv element.
+  const length3Rule = {
+    type: Skyflow.ValidationRuleType.LENGTH_MATCH_RULE,
+    params: {
+      max: 3,
+      error: "cvv must be 3 digits",
+    },
+  };
+
+  const length4Rule = {
+    type: Skyflow.ValidationRuleType.LENGTH_MATCH_RULE,
+    params: {
+      min: 4,
+      error: "cvv must be 4 digits",
+    },
+  };
+
+  // OnChange listener for cardNumber element.
+  cardNumberElement.on(Skyflow.EventName.CHANGE, (state) => {
+    console.log("update validation", state);
+    if (state.isValid) {
+      // update cvv element validation rule.
+      if (findCvvLength(state.value) === 3) {
+        cvvElement.update({ validations: [length3Rule] });
+      } else cvvElement.update({ validations: [length4Rule] });
+    }
+  });
+
+  // update collect elements' properties
+  const updateCollectElementsButton = document.getElementById(
+    "updateCollectElements"
+  );
+  if (updateCollectElementsButton) {
+    updateCollectElementsButton.addEventListener("click", () => {
+      // update label,placeholder on cardholderName,
+      cardHolderNameElement.update({
+        label: "CARDHOLDER NAME",
+        placeholder: "Eg: John",
+        type: Skyflow.ElementType.PIN,
+      });
+
+      // update styles on card number
+      cardNumberElement.update({
+        inputStyles: {
+          base: {
+            color: "blue",
+          },
+        },
+      });
+
+      // update table,coloumn on expiry date
+      expiryDateElement.update({
+        table: "pii_fields",
+        column: "expiration_date",
+      });
+    });
+  }
+
+  // Collect all elements data.
+  const collectButton = document.getElementById("collectPCIData");
+  if (collectButton) {
+    collectButton.addEventListener("click", () => {
+      const collectResponse: Promise<CollectResponse> = collectContainer.collect();
+      collectResponse
+        .then((response) => {
+          console.log(response);
+          response = response;
+          const responseElement = document.getElementById('collectResponse');
+          if (responseElement) {
+            responseElement.innerHTML = JSON.stringify(response, null, 2);
+          }
+        })
+        .catch((err) => {
+          const errorElement = document.getElementById('collectResponse');
+          if (errorElement){
+            errorElement.innerHTML = JSON.stringify(err, null, 2);
+          }
+          console.log(err);
+        });
+    });
+  }
+
+  revealView!.style.visibility = "visible";
+
+  const revealStyleOptions = {
+    inputStyles: {
+      base: {
+        border: "1px solid #eae8ee",
+        padding: "10px 16px",
+        borderRadius: "4px",
+        color: "#1d1d1d",
+        marginTop: "4px",
+        fontFamily: '"Roboto", sans-serif',
+      },
+      global: {
+        "@import":
+          'url("https://fonts.googleapis.com/css2?family=Roboto&display=swap")',
+      },
+    },
+    labelStyles: {
+      base: {
+        fontSize: "16px",
+        fontWeight: "bold",
+        fontFamily: '"Roboto", sans-serif',
+      },
+      global: {
+        "@import":
+          'url("https://fonts.googleapis.com/css2?family=Roboto&display=swap")',
+      },
+    },
+    errorTextStyles: {
+      base: {
+        color: "#f44336",
+        paddingLeft: "20px",
+        fontFamily: '"Roboto", sans-serif',
+      },
+      global: {
+        "@import":
+          'url("https://fonts.googleapis.com/css2?family=Roboto&display=swap")',
+      },
+    },
+  };
+
+  // Create Reveal Elements With Tokens.
+  const fieldsTokenData = response.records[0].fields;
+  const revealContainer = skyflow.container(Skyflow.ContainerType.REVEAL) as RevealContainer;
+  
+  const revealCardNumberElement: RevealElement = revealContainer.create({
+    token: fieldsTokenData.card_number,
+    label: "Card Number",
+    ...revealStyleOptions,
+  });
+  revealCardNumberElement.mount("#revealCardNumber");
+
+  const revealCardCvvElement: RevealElement = revealContainer.create({
+    token: fieldsTokenData.cvv,
+    label: "CVV",
+    ...revealStyleOptions,
+    altText: "###",
+  });
+  revealCardCvvElement.mount("#revealCvv");
+
+  const revealCardExpiryElement: RevealElement = revealContainer.create({
+    token: fieldsTokenData.expiration_date,
+    label: "Card Expiry Date",
+    ...revealStyleOptions,
+  });
+  revealCardExpiryElement.mount("#revealExpiryDate");
+
+  const revealCardholderNameElement: RevealElement = revealContainer.create({
+    token: fieldsTokenData.name,
+    label: "Card Holder Name",
+    ...revealStyleOptions,
+  });
+  revealCardholderNameElement.mount("#revealCardholderName");
+
+  const revealButton = document.getElementById("revealPCIData");
+
+  // update Reveal elements' properties
+  const updateRevealElementsButton = document.getElementById(
+    "updateRevealElements"
+  );
+  if (updateRevealElementsButton) {
+    updateRevealElementsButton.addEventListener("click", () => {
+      // update label,inputStyles on cardholderName,
+      revealCardholderNameElement.update({
+        label: "CARDHOLDER NAME",
+        inputStyles: {
+          base: {
+            color: "#aa11aa",
+          },
+        },
+      });
+
+      // update label,labelSyles on card number
+      revealCardNumberElement.update({
+        label: "CARD NUMBER",
+        labelStyles: {
+          base: {
+            borderWidth: "5px",
+          },
+        },
+      });
+
+      // update redaction,inputStyles on expiry date
+      revealCardExpiryElement.update({
+        redaction: Skyflow.RedactionType.REDACTED,
+        inputStyles: {
+          base: {
+            backgroundColor: "#000",
+            color: "#fff",
+          },
+        },
+      });
+
+      // update altText,token,inputStyles,errorTextStyles on cvv
+      revealCardCvvElement.update({
+        altText: "XXXX-XX",
+        token: "new-random-roken",
+        inputStyles: {
+          base: {
+            color: "#fff",
+            backgroundColor: "#000",
+            borderColor: "#f00",
+            borderWidth: "5px",
+          },
+        },
+        errorTextStyles: {
+          base: {
+            backgroundColor: "#000",
+            border: "1px #f00 solid",
+          },
+        },
+      });
+    });
+  }
+
+  if (revealButton) {
+    revealButton.addEventListener("click", () => {
+      const revealResponse: Promise<RevealResponse> = revealContainer.reveal();
+        revealResponse.then((res) => {
+          console.log(res);
+        })
+        .catch((err) => {
+          console.log(err);
+        });
+    });
+  }
+} catch (err) {
+  console.log(err);
+}

--- a/samples/using-typescript/skyflow-elements/package.json
+++ b/samples/using-typescript/skyflow-elements/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "skyflowelements",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "start": "parcel src/index.html --open",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "license": "ISC",
+  "dependencies": {
+    "skyflow-js": "^2.3.1"
+  },
+  "devDependencies": {
+    "parcel": "^2.0.1"
+  }
+}

--- a/samples/using-typescript/skyflow-elements/src/index.html
+++ b/samples/using-typescript/skyflow-elements/src/index.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Skyflow Elements</title>
+    <style>
+      body {
+        display: flex;
+        flex-direction: column;
+      }
+      .empty-div {
+        height: 100px;
+        width: 350px;
+      }
+      .reveal-view {
+        margin-top: 48px;
+      }
+    </style>
+  </head>
+  <body>
+    <h3>Collect Elements</h3>
+    <!-- COllect Part -->
+    <div>
+      <div id="collectCardNumber" class="empty-div"></div>
+      <div id="collectCvv" class="empty-div"></div>
+      <div id="collectExpiryDate" class="empty-div"></div>
+      <div id="collectCardholderName" class="empty-div"></div>
+      <div>
+        <button id="collectPCIData">Collect PCI Data</button>
+      </div>
+      <div>
+        <pre id="collectResponse"></pre>
+      </div>
+    </div>
+    <!-- Reveal Part-->
+    <div id="revealView" class="reveal-view">
+      <h3>Reveal Elements</h3>
+      <div id="revealCardNumber" class="empty-div"></div>
+      <div id="revealCvv" class="empty-div"></div>
+      <div id="revealExpiryDate" class="empty-div"></div>
+      <div id="revealCardholderName" class="empty-div"></div>
+      <div>
+        <button id="revealPCIData">Reveal PCI Data</button>
+      </div>
+    </div>
+    
+    <script type="module" src="index.js"></script>
+  </body>
+</html>

--- a/samples/using-typescript/skyflow-elements/src/index.ts
+++ b/samples/using-typescript/skyflow-elements/src/index.ts
@@ -45,7 +45,7 @@ try {
       env: Skyflow.Env.PROD,
     }
   }
-  const skyflow = Skyflow.init(config);
+  const skyflow: Skyflow = Skyflow.init(config);
 
   // Create collect Container.
   const collectContainer = skyflow.container(Skyflow.ContainerType.COLLECT) as CollectContainer;

--- a/samples/using-typescript/skyflow-elements/src/index.ts
+++ b/samples/using-typescript/skyflow-elements/src/index.ts
@@ -1,0 +1,246 @@
+/*
+  Copyright (c) 2025 Skyflow, Inc.
+*/
+import Skyflow, {
+  CollectContainer,
+  CollectElement,
+  CollectResponse,
+  RevealContainer,
+  RevealElement,
+  RevealResponse,
+} from 'skyflow-js';
+
+try {
+  const revealView = document.getElementById('revealView');
+  if (revealView) {
+    revealView.style.visibility = 'hidden';
+  }
+  const skyflow = Skyflow.init({
+    vaultID: '<VAULT_ID>',
+    vaultURL: '<VAULT_URL>',
+    getBearerToken: () => {
+      return new Promise((resolve, reject) => {
+        const Http = new XMLHttpRequest();
+
+        Http.onreadystatechange = () => {
+          if (Http.readyState === 4 && Http.status === 200) {
+            const response = JSON.parse(Http.responseText);
+            resolve(response.accessToken);
+          }
+        };
+        const url = '<TOKEN_END_POINT_URL>';
+        Http.open('GET', url);
+        Http.send();
+      });
+    },
+    options: {
+      logLevel: Skyflow.LogLevel.ERROR,
+      env: Skyflow.Env.PROD,
+    }
+  });
+
+  // Create collect Container.
+  const collectContainer = skyflow.container(Skyflow.ContainerType.COLLECT) as CollectContainer;
+
+  // Custom styles for collect elements.
+  const collectStylesOptions = {
+    inputStyles: {
+      base: {
+        border: '1px solid #eae8ee',
+        padding: '10px 16px',
+        borderRadius: '4px',
+        color: '#1d1d1d',
+        marginTop: '4px',
+        fontFamily: '"Roboto", sans-serif'
+      },
+      complete: {
+        color: '#4caf50',
+      },
+      empty: {},
+      focus: {},
+      invalid: {
+        color: '#f44336',
+      },
+      global: {
+        '@import' :'url("https://fonts.googleapis.com/css2?family=Roboto&display=swap")',
+      }
+    },
+    labelStyles: {
+      base: {
+        fontSize: '16px',
+        fontWeight: 'bold',
+        fontFamily: '"Roboto", sans-serif'
+      },
+      global: {
+        '@import' :'url("https://fonts.googleapis.com/css2?family=Roboto&display=swap")',
+      },
+      requiredAsterisk:{
+        color: 'red'
+      }
+    },
+    errorTextStyles: {
+      base: {
+        color: '#f44336',
+        fontFamily: '"Roboto", sans-serif'
+      },
+      global: {
+        '@import' :'url("https://fonts.googleapis.com/css2?family=Roboto&display=swap")',
+      }
+    },
+  };
+
+  // Create collect elements.
+  const cardNumberElement: CollectElement = collectContainer.create({
+    table: 'pii_fields',
+    column: 'primary_card.card_number',
+    ...collectStylesOptions,
+    placeholder: 'card number',
+    label: 'Card Number',
+    type: Skyflow.ElementType.CARD_NUMBER,
+  },{
+    required: true
+  });
+
+  const cvvElement: CollectElement = collectContainer.create({
+    table: 'pii_fields',
+    column: 'primary_card.cvv',
+    ...collectStylesOptions,
+    label: 'Cvv',
+    placeholder: 'cvv',
+    type: Skyflow.ElementType.CVV,
+  });
+
+  const expiryDateElement: CollectElement = collectContainer.create({
+    table: 'pii_fields',
+    column: 'primary_card.expiry_date',
+    ...collectStylesOptions,
+    label: 'Expiry Date',
+    placeholder: 'MM/YYYY',
+    type: Skyflow.ElementType.EXPIRATION_DATE,
+  });
+
+  const cardHolderNameElement: CollectElement = collectContainer.create({
+    table: 'pii_fields',
+    column: 'first_name',
+    ...collectStylesOptions,
+    label: 'Card Holder Name',
+    placeholder: 'cardholder name',
+    type: Skyflow.ElementType.CARDHOLDER_NAME,
+  });
+
+  // Mount the elements.
+  cardNumberElement.mount('#collectCardNumber');
+  cvvElement.mount('#collectCvv');
+  expiryDateElement.mount('#collectExpiryDate');
+  cardHolderNameElement.mount('#collectCardholderName');
+
+  // Collect all elements data.
+  const collectButton = document.getElementById('collectPCIData');
+  if (collectButton) {
+    collectButton.addEventListener('click', () => {
+      const collectResponse: Promise<CollectResponse> = collectContainer.collect();
+      collectResponse
+        .then((response) => {
+          console.log(response);
+          response = response;
+          const responseElement = document.getElementById('collectResponse');
+          if (responseElement) {
+            responseElement.innerHTML = JSON.stringify(response, null, 2);
+          }
+
+          if (revealView) {
+            revealView.style.visibility = 'visible';
+          }
+
+          const revealStyleOptions = {
+            inputStyles: {
+              base: {
+                border: '1px solid #eae8ee',
+                padding: '10px 16px',
+                borderRadius: '4px',
+                color: '#1d1d1d',
+                marginTop: '4px',
+                fontFamily: '"Roboto", sans-serif'
+              },
+              global: {
+                '@import' :'url("https://fonts.googleapis.com/css2?family=Roboto&display=swap")',
+              }
+            },
+            labelStyles: {
+              base: {
+                fontSize: '16px',
+                fontWeight: 'bold',
+                fontFamily: '"Roboto", sans-serif'
+              },
+              global: {
+                '@import' :'url("https://fonts.googleapis.com/css2?family=Roboto&display=swap")',
+              }
+            },
+            errorTextStyles: {
+              base: {
+                color: '#f44336',
+                fontFamily: '"Roboto", sans-serif'
+              },
+              global: {
+                '@import' :'url("https://fonts.googleapis.com/css2?family=Roboto&display=swap")',
+              }
+            },
+          };
+
+          // Create Reveal Elements With Tokens.
+          const fieldsTokenData = response.records[0].fields;
+          const revealContainer = skyflow.container(
+            Skyflow.ContainerType.REVEAL
+          ) as RevealContainer;
+          const revealCardNumberElement: RevealElement = revealContainer.create({
+            token: fieldsTokenData.primary_card.card_number,
+            label: 'Card Number',
+            redaction: Skyflow.RedactionType.MASKED,
+            ...revealStyleOptions,
+          });
+          revealCardNumberElement.mount('#revealCardNumber');
+
+          const revealCardCvvElement: RevealElement = revealContainer.create({
+            token: fieldsTokenData.primary_card.cvv,
+            label: 'CVV',
+            redaction: Skyflow.RedactionType.REDACTED,
+            ...revealStyleOptions,
+            altText: '###',
+          });
+          revealCardCvvElement.mount('#revealCvv');
+
+          const revealCardExpiryElement: RevealElement = revealContainer.create({
+            token: fieldsTokenData.primary_card.expiry_date,
+            label: 'Card Expiry Date',
+            ...revealStyleOptions,
+          });
+          revealCardExpiryElement.mount('#revealExpiryDate');
+
+          const revealCardholderNameElement: RevealElement = revealContainer.create({
+            token: fieldsTokenData.first_name,
+            label: 'Card Holder Name',
+            ...revealStyleOptions,
+          });
+          revealCardholderNameElement.mount('#revealCardholderName');
+
+          const revealButton = document.getElementById('revealPCIData');
+
+          if (revealButton) {
+            revealButton.addEventListener('click', () => {
+              const revealResponse: Promise<RevealResponse> = revealContainer.reveal()
+              revealResponse.then((res) => {
+                console.log(res);
+              }).catch((err) => {
+                console.log(err);
+              });
+            });
+          }
+        })
+        .catch((err) => {
+          console.log(err);
+        });
+    });
+  }
+} catch (err) {
+  console.log(err);
+}

--- a/samples/using-typescript/skyflow-elements/src/index.ts
+++ b/samples/using-typescript/skyflow-elements/src/index.ts
@@ -4,7 +4,14 @@
 import Skyflow, {
   CollectContainer,
   CollectElement,
+  CollectElementInput,
+  CollectElementOptions,
   CollectResponse,
+  ErrorTextStyles,
+  ISkyflow,
+  InputStyles,
+  IRevealElementInput,
+  LabelStyles,
   RevealContainer,
   RevealElement,
   RevealResponse,
@@ -15,7 +22,7 @@ try {
   if (revealView) {
     revealView.style.visibility = 'hidden';
   }
-  const skyflow = Skyflow.init({
+  const config: ISkyflow = {
     vaultID: '<VAULT_ID>',
     vaultURL: '<VAULT_URL>',
     getBearerToken: () => {
@@ -37,7 +44,8 @@ try {
       logLevel: Skyflow.LogLevel.ERROR,
       env: Skyflow.Env.PROD,
     }
-  });
+  }
+  const skyflow = Skyflow.init(config);
 
   // Create collect Container.
   const collectContainer = skyflow.container(Skyflow.ContainerType.COLLECT) as CollectContainer;
@@ -64,7 +72,7 @@ try {
       global: {
         '@import' :'url("https://fonts.googleapis.com/css2?family=Roboto&display=swap")',
       }
-    },
+    } as InputStyles,
     labelStyles: {
       base: {
         fontSize: '16px',
@@ -77,7 +85,7 @@ try {
       requiredAsterisk:{
         color: 'red'
       }
-    },
+    } as LabelStyles,
     errorTextStyles: {
       base: {
         color: '#f44336',
@@ -86,47 +94,52 @@ try {
       global: {
         '@import' :'url("https://fonts.googleapis.com/css2?family=Roboto&display=swap")',
       }
-    },
+    } as ErrorTextStyles,
   };
 
   // Create collect elements.
-  const cardNumberElement: CollectElement = collectContainer.create({
+  const cardNumberInput: CollectElementInput = {
     table: 'pii_fields',
     column: 'primary_card.card_number',
     ...collectStylesOptions,
     placeholder: 'card number',
     label: 'Card Number',
     type: Skyflow.ElementType.CARD_NUMBER,
-  },{
+  }
+  const cardNumberOptions: CollectElementOptions = {
     required: true
-  });
+  }
+  const cardNumberElement: CollectElement = collectContainer.create(cardNumberInput, cardNumberOptions);
 
-  const cvvElement: CollectElement = collectContainer.create({
+  const cvvInput: CollectElementInput = {
     table: 'pii_fields',
     column: 'primary_card.cvv',
     ...collectStylesOptions,
     label: 'Cvv',
     placeholder: 'cvv',
     type: Skyflow.ElementType.CVV,
-  });
+  }
+  const cvvElement: CollectElement = collectContainer.create(cvvInput);
 
-  const expiryDateElement: CollectElement = collectContainer.create({
+  const expiryDateInput: CollectElementInput = {
     table: 'pii_fields',
     column: 'primary_card.expiry_date',
     ...collectStylesOptions,
     label: 'Expiry Date',
     placeholder: 'MM/YYYY',
     type: Skyflow.ElementType.EXPIRATION_DATE,
-  });
+  }
+  const expiryDateElement: CollectElement = collectContainer.create(expiryDateInput);
 
-  const cardHolderNameElement: CollectElement = collectContainer.create({
+  const cardholderNameInput: CollectElementInput = {
     table: 'pii_fields',
     column: 'first_name',
     ...collectStylesOptions,
     label: 'Card Holder Name',
     placeholder: 'cardholder name',
     type: Skyflow.ElementType.CARDHOLDER_NAME,
-  });
+  }
+  const cardHolderNameElement: CollectElement = collectContainer.create(cardholderNameInput);
 
   // Mount the elements.
   cardNumberElement.mount('#collectCardNumber');
@@ -140,7 +153,7 @@ try {
     collectButton.addEventListener('click', () => {
       const collectResponse: Promise<CollectResponse> = collectContainer.collect();
       collectResponse
-        .then((response) => {
+        .then((response: CollectResponse) => {
           console.log(response);
           response = response;
           const responseElement = document.getElementById('collectResponse');
@@ -192,35 +205,40 @@ try {
           const revealContainer = skyflow.container(
             Skyflow.ContainerType.REVEAL
           ) as RevealContainer;
-          const revealCardNumberElement: RevealElement = revealContainer.create({
+          
+          const revealCardNumberInput: IRevealElementInput = {
             token: fieldsTokenData.primary_card.card_number,
             label: 'Card Number',
             redaction: Skyflow.RedactionType.MASKED,
             ...revealStyleOptions,
-          });
+          }
+          const revealCardNumberElement: RevealElement = revealContainer.create(revealCardNumberInput);
           revealCardNumberElement.mount('#revealCardNumber');
 
-          const revealCardCvvElement: RevealElement = revealContainer.create({
+          const revealCardCvvInput: IRevealElementInput = {
             token: fieldsTokenData.primary_card.cvv,
             label: 'CVV',
             redaction: Skyflow.RedactionType.REDACTED,
             ...revealStyleOptions,
             altText: '###',
-          });
+          }
+          const revealCardCvvElement: RevealElement = revealContainer.create(revealCardCvvInput);
           revealCardCvvElement.mount('#revealCvv');
 
-          const revealCardExpiryElement: RevealElement = revealContainer.create({
+          const revealCardExpiryInput: IRevealElementInput = {
             token: fieldsTokenData.primary_card.expiry_date,
             label: 'Card Expiry Date',
             ...revealStyleOptions,
-          });
+          }
+          const revealCardExpiryElement: RevealElement = revealContainer.create(revealCardExpiryInput);
           revealCardExpiryElement.mount('#revealExpiryDate');
 
-          const revealCardholderNameElement: RevealElement = revealContainer.create({
+          const revealCardholderNameInput: IRevealElementInput = {
             token: fieldsTokenData.first_name,
             label: 'Card Holder Name',
             ...revealStyleOptions,
-          });
+          }
+          const revealCardholderNameElement: RevealElement = revealContainer.create(revealCardholderNameInput);
           revealCardholderNameElement.mount('#revealCardholderName');
 
           const revealButton = document.getElementById('revealPCIData');
@@ -228,19 +246,19 @@ try {
           if (revealButton) {
             revealButton.addEventListener('click', () => {
               const revealResponse: Promise<RevealResponse> = revealContainer.reveal()
-              revealResponse.then((res) => {
+              revealResponse.then((res: RevealResponse) => {
                 console.log(res);
-              }).catch((err) => {
+              }).catch((err: RevealResponse) => {
                 console.log(err);
               });
             });
           }
         })
-        .catch((err) => {
+        .catch((err: CollectResponse) => {
           console.log(err);
         });
     });
   }
-} catch (err) {
+} catch (err: unknown) {
   console.log(err);
 }

--- a/src/core/external/reveal/reveal-container.ts
+++ b/src/core/external/reveal/reveal-container.ts
@@ -7,7 +7,10 @@ import iframer, { getIframeSrc, setAttributes, setStyles } from '../../../iframe
 import SkyflowError from '../../../libs/skyflow-error';
 import uuid from '../../../libs/uuid';
 import { ContainerType } from '../../../skyflow';
-import { Context, MessageType, RedactionType } from '../../../utils/common';
+import {
+  Context, MessageType,
+  RedactionType, RevealResponse,
+} from '../../../utils/common';
 import SKYFLOW_ERROR_CODE from '../../../utils/constants';
 import logs from '../../../utils/logs';
 import { parameterizedString, printLog } from '../../../utils/logs-helper';
@@ -146,7 +149,7 @@ class RevealContainer extends Container {
     return revealElement;
   }
 
-  reveal() {
+  reveal(): Promise<RevealResponse> {
     this.#isRevealCalled = true;
     this.#revealRecords = [];
     if (this.#metaData.skyflowContainer.isControllerFrameReady) {

--- a/src/index-node.ts
+++ b/src/index-node.ts
@@ -5,14 +5,18 @@ import Skyflow from './skyflow';
 
 export {
   IInsertRecordInput,
+  IInsertRecord,
   IInsertOptions,
   InsertResponse,
   IDetokenizeInput,
+  IRevealRecord,
   DetokenizeResponse,
   IDeleteRecordInput,
+  IDeleteRecord,
   IDeleteOptions,
   DeleteResponse,
   IGetInput,
+  IGetRecord,
   IGetOptions,
   GetResponse,
   IGetByIdInput,
@@ -28,6 +32,12 @@ export {
   LabelStyles,
   ErrorTextStyles,
   RedactionType,
+  RevealResponse,
+  IValidationRule,
+  ValidationRuleType,
+  EventName,
+  LogLevel,
+  Env,
 } from './utils/common';
 
 export {
@@ -47,8 +57,9 @@ export { ContainerType, ISkyflow } from './skyflow';
 export { default as CollectElement } from './core/external/collect/collect-element';
 export { default as CollectContainer } from './core/external/collect/collect-container';
 export { default as ComposableContainer } from './core/external/collect/compose-collect-container';
-export { default as RevealElement } from './core/external/reveal/reveal-element';
+export { default as ComposableElement } from './core/external/collect/compose-collect-element';
 export { default as RevealContainer } from './core/external/reveal/reveal-container';
+export { default as RevealElement } from './core/external/reveal/reveal-element';
 export { default as ThreeDS } from './core/external/threeds/threeds';
 
 export default Skyflow;

--- a/src/utils/common/index.ts
+++ b/src/utils/common/index.ts
@@ -302,6 +302,17 @@ export interface ICollectOptions {
 }
 
 export interface UploadFilesResponse {
-  fileUploadResponse: [skyflow_id: string],
-  errorResponse: [error: ErrorRecord]
+  fileUploadResponse: [{ skyflow_id: string }],
+  errorResponse: [{ error: ErrorRecord }]
+}
+
+export interface RevealResponse {
+  success?: {
+    token: string,
+    valueType: string,
+  },
+  errors?: {
+    error: ErrorRecord
+    token: string,
+  }
 }

--- a/src/utils/common/index.ts
+++ b/src/utils/common/index.ts
@@ -188,7 +188,7 @@ export interface SharedMeticsObjectType {
 
 export interface InsertResponse {
   records?: InsertResponseRecords[],
-  errors?: ErrorRecord[];
+  errors?: ErrorRecord[],
 }
 
 export interface CollectResponse extends InsertResponse {}
@@ -196,46 +196,46 @@ export interface DetokenizeResponse extends IRevealResponseType {}
 
 export interface InsertResponseRecords {
   fields: Record<string, any>,
-  table: string;
+  table: string,
 }
 
 export interface ErrorRecord {
   code: number,
-  description: string;
+  description: string,
 }
 
 export interface GetByIdResponse {
   records?: GetByIdResponseRecord[],
-  errors?: ErrorRecord[];
+  errors?: ErrorRecord[],
 }
 
 export interface GetByIdResponseRecord {
   fields: Record<string, any>,
-  table: string;
+  table: string,
 }
 
 export interface GetResponse {
   records?: GetResponseRecord[],
-  errors?: ErrorRecord[];
+  errors?: ErrorRecord[],
 }
 
 export interface GetResponseRecord {
   fields: Record<string, any>,
-  table: string;
+  table: string,
 }
 
 export interface DeleteResponse {
   records?: DeleteResponseRecord[],
-  errors?: DeleteErrorRecords[];
+  errors?: DeleteErrorRecords[],
 }
 export interface DeleteResponseRecord {
   skyflow_id: string,
-  deleted: boolean;
+  deleted: boolean,
 }
 
 export interface DeleteErrorRecords {
   id: string,
-  error: ErrorRecord;
+  error: ErrorRecord,
 }
 
 export interface ContainerOptions {
@@ -246,12 +246,12 @@ export interface ContainerOptions {
 
 export interface ErrorTextStyles {
   base?: Record<string, string>,
-  global?: Record<string, string>;
+  global?: Record<string, string>,
 }
 
 export interface LabelStyles extends ErrorTextStyles {
   focus?: Record<string, string>,
-  requiredAsterisk?: Record<string, string>;
+  requiredAsterisk?: Record<string, string>,
 }
 
 export interface InputStyles extends ErrorTextStyles {
@@ -260,7 +260,7 @@ export interface InputStyles extends ErrorTextStyles {
   empty?: Record<string, string>,
   invalid?: Record<string, string>,
   cardIcon?: Record<string, string>,
-  copyIcon?: Record<string, string>
+  copyIcon?: Record<string, string>,
 }
 
 export interface CollectElementOptions {
@@ -278,32 +278,32 @@ export interface CollectElementOptions {
 }
 
 export interface CardMetadata {
-  scheme: CardType[]
+  scheme: CardType[],
 }
 
 export interface CollectElementInput {
-  table?: string;
-  column?: string;
-  label?: string;
-  inputStyles?: InputStyles;
-  labelStyles?: LabelStyles;
-  errorTextStyles?: ErrorTextStyles;
-  placeholder?: string;
-  type: ElementType;
-  altText?: string;
-  validations?: IValidationRule[]
-  skyflowID?: string;
+  table?: string,
+  column?: string,
+  label?: string,
+  inputStyles?: InputStyles,
+  labelStyles?: LabelStyles,
+  errorTextStyles?: ErrorTextStyles,
+  placeholder?: string,
+  type: ElementType,
+  altText?: string,
+  validations?: IValidationRule[],
+  skyflowID?: string,
 }
 
 export interface ICollectOptions {
-  tokens?: boolean;
-  additionalFields?: IInsertRecordInput;
-  upsert?: Array<IUpsertOptions>
+  tokens?: boolean,
+  additionalFields?: IInsertRecordInput,
+  upsert?: Array<IUpsertOptions>,
 }
 
 export interface UploadFilesResponse {
   fileUploadResponse: [{ skyflow_id: string }],
-  errorResponse: [{ error: ErrorRecord }]
+  errorResponse: [{ error: ErrorRecord }],
 }
 
 export interface RevealResponse {
@@ -312,7 +312,7 @@ export interface RevealResponse {
     valueType: string,
   },
   errors?: {
-    error: ErrorRecord
+    error: ErrorRecord,
     token: string,
   }
 }

--- a/tests/core/external/collect/collect-container.test.ts
+++ b/tests/core/external/collect/collect-container.test.ts
@@ -1,0 +1,277 @@
+/*
+Copyright (c) 2025 Skyflow, Inc.
+*/
+import { ElementType } from "../../../../src/core/constants";
+import CollectContainer from "../../../../src/core/external/collect/collect-container";
+import CollectElement from "../../../../src/core/external/collect/collect-element";
+import * as iframerUtils from "../../../../src/iframe-libs/iframer";
+import {
+  LogLevel,
+  Env,
+  CollectElementInput,
+  InputStyles,
+  CollectResponse,
+  ICollectOptions,
+  UploadFilesResponse,
+  CollectElementOptions,
+} from "../../../../src/utils/common";
+
+global.ResizeObserver = jest.fn().mockImplementation(() => ({
+  observe: jest.fn(),
+  disconnect: jest.fn(),
+  unobserve: jest.fn(),
+}));
+
+const bus = require("framebus");
+
+jest
+  .spyOn(iframerUtils, "getIframeSrc")
+  .mockImplementation(() => "https://google.com");
+
+const getBearerToken = jest.fn().mockImplementation(() => Promise.resolve());
+
+const mockUuid = "1234";
+jest.mock("../../../../src/libs/uuid", () => ({
+  __esModule: true,
+  default: jest.fn(() => mockUuid),
+}));
+
+const metaData = {
+  uuid: "123",
+  skyflowContainer: {
+    isControllerFrameReady: true,
+  },
+  config: {
+    vaultID: "vault123",
+    vaultURL: "https://sb.vault.dev",
+    getBearerToken,
+  },
+  metaData: {
+    clientDomain: "http://abc.com",
+  },
+  clientJSON: {
+    config: {
+      vaultID: "vault123",
+      vaultURL: "https://sb.vault.dev",
+      getBearerToken,
+    },
+  },
+};
+const metaData2 = {
+  uuid: "123",
+  skyflowContainer: {
+    isControllerFrameReady: false,
+  },
+  config: {
+    vaultID: "vault123",
+    vaultURL: "https://sb.vault.dev",
+    getBearerToken,
+  },
+  metaData: {
+    clientDomain: "http://abc.com",
+  },
+  clientJSON: {
+    config: {
+      vaultID: "vault123",
+      vaultURL: "https://sb.vault.dev",
+      getBearerToken,
+    },
+  },
+};
+
+const collectStylesOptions = {
+  inputStyles: {
+    cardIcon: {
+      position: "absolute",
+      left: "8px",
+      top: "calc(50% - 10px)",
+    },
+  } as InputStyles,
+};
+
+const cvvElement: CollectElementInput = {
+  table: "pii_fields",
+  column: "primary_card.cvv",
+  placeholder: "cvv",
+  label: "cvv",
+  type: ElementType.CVV,
+  ...collectStylesOptions,
+};
+
+const cardNumberElement: CollectElementInput = {
+  table: "pii_fields",
+  column: "primary_card.card_number",
+  type: ElementType.CARD_NUMBER,
+  ...collectStylesOptions,
+};
+
+const ExpirationDateElement: CollectElementInput = {
+  table: "pii_fields",
+  column: "primary_card.expiry",
+  type: ElementType.EXPIRATION_DATE,
+};
+
+const FileElement: CollectElementInput = {
+  table: "pii_fields",
+  column: "primary_card.file",
+  type: ElementType.FILE_INPUT,
+  skyflowID: "abc-def",
+};
+
+const on = jest.fn();
+
+// const collectResponse: CollectResponse = {
+//   records: [
+//     {
+//       table: "table",
+//       fields: {
+//         first_name: "token1",
+//         primary_card: {
+//           card_number: "token2",
+//           cvv: "token3",
+//         },
+//       },
+//     },
+//   ],
+// };
+// const collectResponse2: CollectResponse = {
+//   errors: [
+//     {
+//       description: "error",
+//       code: 200,
+//     },
+//   ],
+// };
+
+const options: ICollectOptions = {
+  tokens: true,
+  additionalFields: {
+    records: [
+      {
+        table: "pii_fields",
+        fields: {
+          "primary_card.cvv": "1234",
+        },
+      },
+    ],
+  },
+};
+
+describe("Collect container", () => {
+  let emitSpy: jest.SpyInstance;
+  let targetSpy: jest.SpyInstance;
+  let onSpy: jest.SpyInstance;
+  beforeEach(() => {
+    // emitSpy = null;
+    // targetSpy = null;
+    // onSpy = null;
+    emitSpy = jest.spyOn(bus, "emit");
+    targetSpy = jest.spyOn(bus, "target");
+    onSpy = jest.spyOn(bus, "on");
+    targetSpy.mockReturnValue({
+      on,
+      off: jest.fn(),
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    jest.restoreAllMocks();
+    document.body.innerHTML = "";
+  });
+
+  it("container collect success", () => {
+    let collectContainer = new CollectContainer(
+      {},
+      metaData,
+      {},
+      { logLevel: LogLevel.ERROR, env: Env.PROD }
+    );
+    const div1 = document.createElement("div");
+    const div2 = document.createElement("div");
+
+    const element1: CollectElement = collectContainer.create(cvvElement);
+    const element2: CollectElement = collectContainer.create(cardNumberElement);
+
+    element1.mount(div1);
+    element2.mount(div2);
+
+    const mountCvvCb = onSpy.mock.calls[2][1];
+
+    mountCvvCb({
+      name: `element:${cvvElement.type}:${btoa(element1.getID())}`,
+    });
+
+    const mountCardNumberCb = onSpy.mock.calls[5][1];
+    mountCardNumberCb({
+      name: `element:${cardNumberElement.type}:${btoa(element2.getID())}`,
+    });
+
+    collectContainer
+      .collect(options)
+      .then()
+      .catch((err: CollectResponse) => {
+        expect(err).toBeDefined();
+      });
+
+    const collectRequestCb = emitSpy.mock.calls[2][2];
+    collectRequestCb({
+      data: {},
+    });
+
+    collectRequestCb({
+      error: "error",
+    });
+  });
+
+  it("should successfully upload files when elements are mounted", async () => {
+    const container = new CollectContainer(
+      {},
+      metaData,
+      {},
+      { logLevel: LogLevel.ERROR, env: Env.PROD }
+    );
+    const div = document.createElement("div");
+    const fileElement = container.create(FileElement);
+
+    fileElement.mount(div);
+
+    const mountCb = onSpy.mock.calls[2][1];
+    mountCb({
+      name: `element:${FileElement.type}:${btoa(fileElement.getID())}`,
+    });
+
+    const uploadPromise: Promise<UploadFilesResponse> = container.uploadFiles({
+      tokens: true,
+    });
+
+    const uploadRequestCb = emitSpy.mock.calls[1][2];
+    uploadRequestCb({
+      fileUploadResonse: [{ skyflow_id: "1234" }],
+    });
+
+    const expectedResponse = await uploadPromise;
+    console.log(JSON.stringify(expectedResponse, null, 2))
+
+    expect(expectedResponse).toBeDefined();
+  });
+
+  it("tests different collect element options for elements", () => {
+    const container = new CollectContainer(
+      {},
+      metaData,
+      {},
+      { logLevel: LogLevel.ERROR, env: Env.PROD }
+    );
+    let expiryElement: CollectElement;
+    let elementOptions: CollectElementOptions = {
+      required: true,
+      enableCardIcon: true,
+      enableCopy: true,
+    };
+    expiryElement = container.create(ExpirationDateElement, elementOptions);
+    const options = expiryElement.getOptions();
+    expect(options.enableCardIcon).toBe(true);
+    expect(options.enableCopy).toBe(true);
+  });
+});

--- a/tests/core/external/collect/collect-container.test.ts
+++ b/tests/core/external/collect/collect-container.test.ts
@@ -120,29 +120,6 @@ const FileElement: CollectElementInput = {
 
 const on = jest.fn();
 
-// const collectResponse: CollectResponse = {
-//   records: [
-//     {
-//       table: "table",
-//       fields: {
-//         first_name: "token1",
-//         primary_card: {
-//           card_number: "token2",
-//           cvv: "token3",
-//         },
-//       },
-//     },
-//   ],
-// };
-// const collectResponse2: CollectResponse = {
-//   errors: [
-//     {
-//       description: "error",
-//       code: 200,
-//     },
-//   ],
-// };
-
 const options: ICollectOptions = {
   tokens: true,
   additionalFields: {
@@ -162,9 +139,6 @@ describe("Collect container", () => {
   let targetSpy: jest.SpyInstance;
   let onSpy: jest.SpyInstance;
   beforeEach(() => {
-    // emitSpy = null;
-    // targetSpy = null;
-    // onSpy = null;
     emitSpy = jest.spyOn(bus, "emit");
     targetSpy = jest.spyOn(bus, "target");
     onSpy = jest.spyOn(bus, "on");

--- a/tests/skyflow.test.ts
+++ b/tests/skyflow.test.ts
@@ -1,0 +1,861 @@
+/*
+Copyright (c) 2025 Skyflow, Inc.
+*/
+import bus from "framebus";
+import Skyflow, { ISkyflow } from "../src/skyflow";
+import * as iframerUtils from "../src/iframe-libs/iframer";
+import { ELEMENT_EVENTS_TO_IFRAME } from "../src/core/constants";
+import {
+  DeleteResponse,
+  DeleteResponseRecord,
+  DetokenizeResponse,
+  GetByIdResponse,
+  GetByIdResponseRecord,
+  GetResponse,
+  GetResponseRecord,
+  IDeleteOptions,
+  IDeleteRecord,
+  IDeleteRecordInput,
+  IDetokenizeInput,
+  IGetByIdInput,
+  IGetInput,
+  IGetOptions,
+  IGetRecord,
+  IInsertOptions,
+  IInsertRecord,
+  IInsertRecordInput,
+  InsertResponse,
+  InsertResponseRecords,
+  IRevealRecord,
+  ISkyflowIdRecord,
+  RedactionType,
+} from "../src/utils/common";
+
+jest.mock("../src/utils/jwt-utils", () => ({
+  __esModule: true,
+  default: jest.fn(() => true),
+}));
+jest.mock("../src/libs/uuid", () => ({
+  __esModule: true,
+  default: jest.fn(() => "b5cbf425-6578-4d40-be88-82a748c36c60"),
+}));
+jest
+  .spyOn(iframerUtils, "getIframeSrc")
+  .mockImplementation(() => "https://google.com");
+
+describe("Skyflow initialization", () => {
+  test("should initialize the skyflow object  ", () => {
+    const config: ISkyflow = {
+      vaultID: "vault_id",
+      vaultURL: "https://vault.test.com",
+      getBearerToken: jest.fn(),
+    };
+    const skyflow = Skyflow.init(config);
+    expect(skyflow.constructor === Skyflow).toBe(true);
+  });
+
+  test("should initialize the skyflow object with custom url  ", () => {
+    const config: ISkyflow = {
+      vaultID: "vault_id",
+      vaultURL: "https://vault.test.com",
+      getBearerToken: jest.fn(),
+      options: {
+        customElementsURL: "https://js.skyflow.com/v1/elements/index.html",
+      },
+    };
+    const skyflow = Skyflow.init(config);
+    expect(skyflow.constructor === Skyflow).toBe(true);
+  });
+});
+
+// insert records, options and responses
+const insertRecord: IInsertRecord = {
+  table: "pii_fields",
+  fields: {
+    first_name: "joey",
+    primary_card: {
+      card_number: "411",
+      cvv: "123",
+    },
+  },
+};
+const records: IInsertRecordInput = {
+  records: [insertRecord],
+};
+const options: IInsertOptions = {
+  tokens: true,
+};
+const insertResponseRecord: InsertResponseRecords = {
+  table: "pii_fields",
+  fields: {
+    first_name: "token1",
+    primary_card: {
+      card_number: "token2",
+      cvv: "token3",
+    },
+  },
+};
+const insertResponse: InsertResponse = {
+  records: [insertResponseRecord],
+};
+
+const on = jest.fn();
+
+describe("skyflow insert", () => {
+  let emitSpy: jest.SpyInstance;
+  let targetSpy: jest.SpyInstance;
+  let skyflow: Skyflow;
+  beforeEach(() => {
+    emitSpy = jest.spyOn(bus, "emit");
+    targetSpy = jest.spyOn(bus, "target");
+    targetSpy.mockReturnValue({
+      on,
+    });
+
+    const config: ISkyflow = {
+      vaultID: "vault123",
+      vaultURL: "https://vaulturl.com",
+      getBearerToken: jest.fn(),
+    };
+    skyflow = Skyflow.init(config);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("insert success", (done) => {
+    const frameReayEvent = on.mock.calls.filter((data) =>
+      data[0].includes(ELEMENT_EVENTS_TO_IFRAME.PUREJS_FRAME_READY)
+    );
+    const frameReadyCb = frameReayEvent[0][1];
+    const cb2 = jest.fn();
+    frameReadyCb({}, cb2);
+    try {
+      const res: Promise<InsertResponse> = skyflow.insert(records);
+
+      const emitEvent = emitSpy.mock.calls.filter((data) =>
+        data[0].includes(ELEMENT_EVENTS_TO_IFRAME.PUREJS_REQUEST)
+      );
+      const emitCb = emitEvent[0][2];
+      emitCb(insertResponse);
+
+      let data: InsertResponse;
+      res.then((res) => (data = res));
+
+      setTimeout(() => {
+        expect(data.records!.length).toBe(1);
+        expect(data.errors).toBeUndefined();
+        done();
+      }, 1000);
+    } catch (err) {}
+  });
+
+  test("insert error", (done) => {
+    const frameReayEvent = on.mock.calls.filter((data) =>
+      data[0].includes(ELEMENT_EVENTS_TO_IFRAME.PUREJS_FRAME_READY)
+    );
+    const frameReadyCb = frameReayEvent[0][1];
+    const cb2 = jest.fn();
+    frameReadyCb({}, cb2);
+    try {
+      const res: Promise<InsertResponse> = skyflow.insert(records);
+
+      const emitEvent = emitSpy.mock.calls.filter((data) =>
+        data[0].includes(ELEMENT_EVENTS_TO_IFRAME.PUREJS_REQUEST)
+      );
+      const emitCb = emitEvent[0][2];
+      emitCb({ error: { message: "resource doesn't exist", code: 404 } });
+
+      let error: InsertResponse;
+      res.catch((err) => (error = err));
+
+      setTimeout(() => {
+        expect(error).toBeDefined();
+        done();
+      }, 1000);
+    } catch (err) {}
+  });
+});
+
+// detokenize records, options and responses
+const detokenizeInput: IDetokenizeInput = {
+  records: [
+    {
+      token: "token1",
+    } as IRevealRecord,
+  ],
+};
+const detokenizeRes: DetokenizeResponse = {
+  records: [
+    {
+      token: "token1",
+      cvv: "123",
+    },
+  ],
+};
+
+describe("skyflow detokenize", () => {
+  let emitSpy: jest.SpyInstance;
+  let targetSpy: jest.SpyInstance;
+  let skyflow: Skyflow;
+  const emit = jest.fn();
+  const on = jest.fn();
+  beforeEach(() => {
+    emitSpy = jest.spyOn(bus, "emit");
+    targetSpy = jest.spyOn(bus, "target");
+    targetSpy.mockReturnValue({
+      on,
+      emit,
+    });
+
+    skyflow = Skyflow.init({
+      vaultID: "vault123",
+      vaultURL: "https://vaulturl.com",
+      getBearerToken: jest.fn(),
+    } as ISkyflow);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    jest.resetAllMocks();
+  });
+
+  test("detokenize success", (done) => {
+    const frameReayEvent = on.mock.calls.filter((data) =>
+      data[0].includes(ELEMENT_EVENTS_TO_IFRAME.PUREJS_FRAME_READY)
+    );
+    const frameReadyCb = frameReayEvent[0][1];
+    const cb2 = jest.fn();
+    frameReadyCb({}, cb2);
+    try {
+      const res: Promise<DetokenizeResponse> =
+        skyflow.detokenize(detokenizeInput);
+
+      const emitEvent = emitSpy.mock.calls.filter((data) =>
+        data[0].includes(ELEMENT_EVENTS_TO_IFRAME.PUREJS_REQUEST)
+      );
+      const emitCb = emitEvent[0][2];
+      emitCb(detokenizeRes);
+
+      let data: DetokenizeResponse;
+      res.then((res) => (data = res));
+
+      setTimeout(() => {
+        expect(data.records!.length).toBe(1);
+        expect(data.errors).toBeUndefined();
+        done();
+      }, 1000);
+    } catch (err) {}
+  });
+
+  test("detokenize error", (done) => {
+    const frameReayEvent = on.mock.calls.filter((data) =>
+      data[0].includes(ELEMENT_EVENTS_TO_IFRAME.PUREJS_FRAME_READY)
+    );
+    const frameReadyCb = frameReayEvent[0][1];
+    const cb2 = jest.fn();
+    frameReadyCb({}, cb2);
+    try {
+      const res: Promise<DetokenizeResponse> =
+        skyflow.detokenize(detokenizeInput);
+
+      const emitEvent = emitSpy.mock.calls.filter((data) =>
+        data[0].includes(ELEMENT_EVENTS_TO_IFRAME.PUREJS_REQUEST)
+      );
+      const emitCb = emitEvent[0][2];
+      emitCb({ error: { message: "token doesn't exist", code: 404 } });
+
+      let error: DetokenizeResponse;
+      res.catch((err) => (error = err));
+
+      setTimeout(() => {
+        expect(error).toBeDefined();
+        done();
+      }, 1000);
+    } catch (err) {}
+  });
+});
+
+// getById records, options and responses
+const getByIdRecord: ISkyflowIdRecord = {
+  ids: ["skyflowId1"],
+  table: "pii_fields",
+  redaction: RedactionType.PLAIN_TEXT,
+};
+const getByIdInput: IGetByIdInput = {
+  records: [getByIdRecord],
+};
+const getByIdRecordWithoutRedaction: IGetRecord = {
+  ids: ["skyflowId1"],
+  table: "pii_fields",
+};
+const getByIdInputWithoutRedaction = {
+  records: [getByIdRecordWithoutRedaction],
+};
+const getByIdResRecord: GetByIdResponseRecord = {
+  fields: {
+    cvv: "123",
+  },
+  table: "pii_fields",
+};
+const getByIdRes: GetByIdResponse = {
+  records: [getByIdResRecord],
+};
+
+// get records, options and responses
+const getRecord: IGetRecord = {
+  columnName: "cvv",
+  columnValues: ["123"],
+  table: "pii_fields",
+  redaction: Skyflow.RedactionType.PLAIN_TEXT,
+};
+const getInput: IGetInput = {
+  records: [getRecord],
+};
+const getOptionsTrue: IGetOptions = { tokens: true };
+const getOptionsFalse: IGetOptions = { tokens: false };
+const getResRecord: GetResponseRecord = {
+  fields: {
+    name: "test",
+    cvv: "123",
+  },
+  table: "pii_fields",
+};
+const getRes: GetResponse = {
+  records: [getResRecord],
+};
+
+describe("skyflow get", () => {
+  let emitSpy: jest.SpyInstance;
+  let targetSpy: jest.SpyInstance;
+  let skyflow: Skyflow;
+  beforeEach(() => {
+    emitSpy = jest.spyOn(bus, "emit");
+    targetSpy = jest.spyOn(bus, "target");
+    targetSpy.mockReturnValue({
+      on,
+    });
+
+    skyflow = Skyflow.init({
+      vaultID: "vault123",
+      vaultURL: "https://vaulturl.com",
+      getBearerToken: jest.fn(),
+    } as ISkyflow);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("get success", (done) => {
+    const frameReayEvent = on.mock.calls.filter((data) =>
+      data[0].includes(ELEMENT_EVENTS_TO_IFRAME.PUREJS_FRAME_READY)
+    );
+    const frameReadyCb = frameReayEvent[0][1];
+    const cb2 = jest.fn();
+    frameReadyCb({}, cb2);
+    try {
+      const res: Promise<GetResponse> = skyflow.get(getByIdInput);
+
+      const emitEvent = emitSpy.mock.calls.filter((data) =>
+        data[0].includes(ELEMENT_EVENTS_TO_IFRAME.PUREJS_REQUEST)
+      );
+      const emitCb = emitEvent[0][2];
+      emitCb(getByIdRes);
+
+      let data: GetResponse;
+      res.then((res) => (data = res));
+
+      setTimeout(() => {
+        expect(data.records!.length).toBe(1);
+        expect(data.errors).toBeUndefined();
+        done();
+      }, 1000);
+    } catch (err) {}
+  });
+
+  test("get error", (done) => {
+    const frameReayEvent = on.mock.calls.filter((data) =>
+      data[0].includes(ELEMENT_EVENTS_TO_IFRAME.PUREJS_FRAME_READY)
+    );
+    const frameReadyCb = frameReayEvent[0][1];
+    const cb2 = jest.fn();
+    frameReadyCb({}, cb2);
+    try {
+      const res: Promise<GetResponse> = skyflow.get(getByIdInput);
+
+      const emitEvent = emitSpy.mock.calls.filter((data) =>
+        data[0].includes(ELEMENT_EVENTS_TO_IFRAME.PUREJS_REQUEST)
+      );
+      const emitCb = emitEvent[0][2];
+      emitCb({ error: { message: "id doesn't exist", code: 404 } });
+
+      let error: GetResponse;
+      res.catch((err) => (error = err));
+
+      setTimeout(() => {
+        expect(error).toBeDefined();
+        done();
+      }, 1000);
+    } catch (err) {}
+  });
+});
+
+describe("skyflow getById", () => {
+  let emitSpy: jest.SpyInstance;
+  let targetSpy: jest.SpyInstance;
+  let skyflow: Skyflow;
+  beforeEach(() => {
+    emitSpy = jest.spyOn(bus, "emit");
+    targetSpy = jest.spyOn(bus, "target");
+    targetSpy.mockReturnValue({
+      on,
+    });
+
+    skyflow = Skyflow.init({
+      vaultID: "vault123",
+      vaultURL: "https://vaulturl.com",
+      getBearerToken: jest.fn(),
+    } as ISkyflow);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("getById success", (done) => {
+    const frameReayEvent = on.mock.calls.filter((data) =>
+      data[0].includes(ELEMENT_EVENTS_TO_IFRAME.PUREJS_FRAME_READY)
+    );
+    const frameReadyCb = frameReayEvent[0][1];
+    const cb2 = jest.fn();
+    frameReadyCb({}, cb2);
+    try {
+      const res: Promise<GetByIdResponse> = skyflow.getById(getByIdInput);
+
+      const emitEvent = emitSpy.mock.calls.filter((data) =>
+        data[0].includes(ELEMENT_EVENTS_TO_IFRAME.PUREJS_REQUEST)
+      );
+      const emitCb = emitEvent[0][2];
+      emitCb(getByIdRes);
+
+      let data: GetByIdResponse;
+      res.then((res) => (data = res));
+
+      setTimeout(() => {
+        expect(data.records!.length).toBe(1);
+        expect(data.errors).toBeUndefined();
+        done();
+      }, 1000);
+    } catch (err) {}
+  });
+
+  test("getById error", (done) => {
+    const frameReayEvent = on.mock.calls.filter((data) =>
+      data[0].includes(ELEMENT_EVENTS_TO_IFRAME.PUREJS_FRAME_READY)
+    );
+    const frameReadyCb = frameReayEvent[0][1];
+    const cb2 = jest.fn();
+    frameReadyCb({}, cb2);
+    try {
+      const res: Promise<GetByIdResponse> = skyflow.getById(getByIdInput);
+
+      const emitEvent = emitSpy.mock.calls.filter((data) =>
+        data[0].includes(ELEMENT_EVENTS_TO_IFRAME.PUREJS_REQUEST)
+      );
+      const emitCb = emitEvent[0][2];
+      emitCb({ error: { message: "id doesn't exist", code: 404 } });
+
+      let error: GetByIdResponse;
+      res.catch((err) => (error = err));
+
+      setTimeout(() => {
+        expect(error).toBeDefined();
+        done();
+      }, 1000);
+    } catch (err) {}
+  });
+});
+
+describe("skyflow get", () => {
+  let emitSpy: jest.SpyInstance;
+  let targetSpy: jest.SpyInstance;
+  let skyflow: Skyflow;
+  beforeEach(() => {
+    emitSpy = jest.spyOn(bus, "emit");
+    targetSpy = jest.spyOn(bus, "target");
+    targetSpy.mockReturnValue({
+      on,
+    });
+
+    skyflow = Skyflow.init({
+      vaultID: "vault123",
+      vaultURL: "https://vaulturl.com",
+      getBearerToken: jest.fn(),
+    } as ISkyflow);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("get success", (done) => {
+    const frameReayEvent = on.mock.calls.filter((data) =>
+      data[0].includes(ELEMENT_EVENTS_TO_IFRAME.PUREJS_FRAME_READY)
+    );
+    const frameReadyCb = frameReayEvent[0][1];
+    const cb2 = jest.fn();
+    frameReadyCb({}, cb2);
+    try {
+      const res: Promise<GetResponse> = skyflow.get(getByIdInput);
+
+      const emitEvent = emitSpy.mock.calls.filter((data) =>
+        data[0].includes(ELEMENT_EVENTS_TO_IFRAME.PUREJS_REQUEST)
+      );
+      const emitCb = emitEvent[0][2];
+      emitCb(getByIdRes);
+
+      let data: GetResponse;
+      res.then((res) => (data = res));
+
+      setTimeout(() => {
+        expect(data.records!.length).toBe(1);
+        expect(data.errors).toBeUndefined();
+        done();
+      }, 1000);
+    } catch (err) {}
+  });
+
+  test("get error", (done) => {
+    const frameReayEvent = on.mock.calls.filter((data) =>
+      data[0].includes(ELEMENT_EVENTS_TO_IFRAME.PUREJS_FRAME_READY)
+    );
+    const frameReadyCb = frameReayEvent[0][1];
+    const cb2 = jest.fn();
+    frameReadyCb({}, cb2);
+    try {
+      const res: Promise<GetResponse> = skyflow.get(getByIdInput);
+
+      const emitEvent = emitSpy.mock.calls.filter((data) =>
+        data[0].includes(ELEMENT_EVENTS_TO_IFRAME.PUREJS_REQUEST)
+      );
+      const emitCb = emitEvent[0][2];
+      emitCb({ error: { message: "id doesn't exist", code: 404 } });
+
+      let error: GetResponse;
+      res.catch((err) => (error = err));
+
+      setTimeout(() => {
+        expect(error).toBeDefined();
+        done();
+      }, 1000);
+    } catch (err) {}
+  });
+
+  test("get success", (done) => {
+    const frameReayEvent = on.mock.calls.filter((data) =>
+      data[0].includes(ELEMENT_EVENTS_TO_IFRAME.PUREJS_FRAME_READY)
+    );
+    const frameReadyCb = frameReayEvent[0][1];
+    const cb2 = jest.fn();
+    frameReadyCb({}, cb2);
+    try {
+      const res: Promise<GetResponse> = skyflow.get(getInput);
+
+      const emitEvent = emitSpy.mock.calls.filter((data) =>
+        data[0].includes(ELEMENT_EVENTS_TO_IFRAME.PUREJS_REQUEST)
+      );
+      const emitCb = emitEvent[0][2];
+      emitCb(getRes);
+
+      let data: GetResponse;
+      res.then((res) => (data = res));
+
+      setTimeout(() => {
+        expect(data.records!.length).toBe(1);
+        expect(data.errors).toBeUndefined();
+        done();
+      }, 1000);
+    } catch (err) {}
+  });
+
+  test("get error", (done) => {
+    const frameReayEvent = on.mock.calls.filter((data) =>
+      data[0].includes(ELEMENT_EVENTS_TO_IFRAME.PUREJS_FRAME_READY)
+    );
+    const frameReadyCb = frameReayEvent[0][1];
+    const cb2 = jest.fn();
+    frameReadyCb({}, cb2);
+    try {
+      const res: Promise<GetResponse> = skyflow.get(getInput);
+
+      const emitEvent = emitSpy.mock.calls.filter((data) =>
+        data[0].includes(ELEMENT_EVENTS_TO_IFRAME.PUREJS_REQUEST)
+      );
+      const emitCb = emitEvent[0][2];
+      emitCb({ error: { message: "id doesn't exist", code: 404 } });
+
+      let error: GetResponse;
+      res.catch((err) => (error = err));
+
+      setTimeout(() => {
+        expect(error).toBeDefined();
+        done();
+      }, 1000);
+    } catch (err) {}
+  });
+});
+
+describe("skyflow get with options", () => {
+  let emitSpy: jest.SpyInstance;
+  let targetSpy: jest.SpyInstance;
+  let skyflow: Skyflow;
+  beforeEach(() => {
+    emitSpy = jest.spyOn(bus, "emit");
+    targetSpy = jest.spyOn(bus, "target");
+    targetSpy.mockReturnValue({
+      on,
+    });
+
+    skyflow = Skyflow.init({
+      vaultID: "vault123",
+      vaultURL: "https://vaulturl.com",
+      getBearerToken: jest.fn(),
+    } as ISkyflow);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("get method success when tokens flag is true", (done) => {
+    const frameReayEvent = on.mock.calls.filter((data) =>
+      data[0].includes(ELEMENT_EVENTS_TO_IFRAME.PUREJS_FRAME_READY)
+    );
+    const frameReadyCb = frameReayEvent[0][1];
+    const cb2 = jest.fn();
+    frameReadyCb({}, cb2);
+    try {
+      const res: Promise<GetResponse> = skyflow.get(
+        getByIdInputWithoutRedaction,
+        getOptionsTrue
+      );
+
+      const emitEvent = emitSpy.mock.calls.filter((data) =>
+        data[0].includes(ELEMENT_EVENTS_TO_IFRAME.PUREJS_REQUEST)
+      );
+      const emitCb = emitEvent[0][2];
+      emitCb(getByIdRes);
+
+      let data: GetResponse;
+      res.then((res) => (data = res));
+
+      setTimeout(() => {
+        expect(data.records!.length).toBe(1);
+        expect(data.errors).toBeUndefined();
+        done();
+      }, 1000);
+    } catch (err) {
+      done(err);
+    }
+  });
+
+  test("get method success when tokens flag is false", (done) => {
+    const frameReayEvent = on.mock.calls.filter((data) =>
+      data[0].includes(ELEMENT_EVENTS_TO_IFRAME.PUREJS_FRAME_READY)
+    );
+    const frameReadyCb = frameReayEvent[0][1];
+    const cb2 = jest.fn();
+    frameReadyCb({}, cb2);
+    try {
+      const res: Promise<GetResponse> = skyflow.get(
+        getByIdInput,
+        getOptionsFalse
+      );
+
+      const emitEvent = emitSpy.mock.calls.filter((data) =>
+        data[0].includes(ELEMENT_EVENTS_TO_IFRAME.PUREJS_REQUEST)
+      );
+      const emitCb = emitEvent[0][2];
+      emitCb(getByIdRes);
+
+      let data: GetResponse;
+      res.then((res) => (data = res));
+
+      setTimeout(() => {
+        expect(data.records!.length).toBe(1);
+        expect(data.errors).toBeUndefined();
+        done();
+      }, 1000);
+    } catch (err) {
+      done(err);
+    }
+  });
+});
+
+// delete records, options and responses
+const deleteRecord: IDeleteRecord = {
+  table: "pii_fields",
+  id: "29ebda8d-5272-4063-af58-15cc674e332b",
+};
+const deleteRecords: IDeleteRecordInput = {
+  records: [deleteRecord],
+};
+const deleteOptions: IDeleteOptions = {};
+const deleteResponseRecord: DeleteResponseRecord = {
+  skyflow_id: "29ebda8d-5272-4063-af58-15cc674e332b",
+  deleted: true,
+};
+const deleteResponse: DeleteResponse = {
+  records: [deleteResponseRecord],
+};
+
+describe("Skyflow delete tests", () => {
+  let emitSpy: jest.SpyInstance;
+  let targetSpy: jest.SpyInstance;
+  let skyflow: Skyflow;
+  const on = jest.fn();
+  const emit = jest.fn();
+  beforeEach(() => {
+    emitSpy = jest.spyOn(bus, "emit");
+    targetSpy = jest.spyOn(bus, "target");
+    targetSpy.mockReturnValue({
+      on,
+      emit,
+    });
+
+    skyflow = Skyflow.init({
+      vaultID: "vault123",
+      vaultURL: "https://vaulturl.com",
+      getBearerToken: jest.fn(),
+    } as ISkyflow);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("delete success", (done) => {
+    const frameReadyEvent = on.mock.calls.filter((data) =>
+      data[0].includes(ELEMENT_EVENTS_TO_IFRAME.PUREJS_FRAME_READY)
+    );
+    const frameReadyCb = frameReadyEvent[0][1];
+    const cb2 = jest.fn();
+    frameReadyCb({}, cb2);
+    try {
+      const res: Promise<DeleteResponse> = skyflow.delete(deleteRecords);
+      const emitEvent = emitSpy.mock.calls.filter((data) =>
+        data[0].includes(ELEMENT_EVENTS_TO_IFRAME.PUREJS_REQUEST)
+      );
+      const emitCb = emitEvent[0][2];
+      emitCb(deleteResponse);
+
+      let data: DeleteResponse;
+      res.then((res: DeleteResponse) => {
+        try {
+          data = res;
+          expect(data.records!.length).toBe(1);
+          expect(data.records![0].deleted).toBeTruthy();
+          expect(data.errors).toBeUndefined();
+          done();
+        } catch (err) {
+          done(err);
+        }
+      });
+    } catch (err) {
+      done(err);
+    }
+  });
+
+  test("delete error", (done) => {
+    const frameReayEvent = on.mock.calls.filter((data) =>
+      data[0].includes(ELEMENT_EVENTS_TO_IFRAME.PUREJS_FRAME_READY)
+    );
+    const frameReadyCb = frameReayEvent[0][1];
+    const cb2 = jest.fn();
+    frameReadyCb({}, cb2);
+    try {
+      const res: Promise<DeleteResponse> = skyflow.delete(deleteRecords);
+
+      const emitEvent = emitSpy.mock.calls.filter((data) =>
+        data[0].includes(ELEMENT_EVENTS_TO_IFRAME.PUREJS_REQUEST)
+      );
+      const emitCb = emitEvent[0][2];
+      emitCb({ error: { message: "No Records Found", code: 404 } });
+
+      let error: DeleteResponse;
+      res.catch((err: DeleteResponse) => {
+        try {
+          error = err;
+          expect(error).toBeDefined();
+          done();
+        } catch (err) {
+          done(err);
+        }
+      });
+    } catch (err) {
+      done(err);
+    }
+  });
+
+  test("delete success else", (done) => {
+    try {
+      const res: Promise<DeleteResponse> = skyflow.delete(deleteRecords);
+
+      const frameReadyEvent = on.mock.calls.filter((data) =>
+        data[0].includes(ELEMENT_EVENTS_TO_IFRAME.PUREJS_FRAME_READY)
+      );
+      const frameReadyCb = frameReadyEvent[1][1];
+      frameReadyCb();
+      const emitEvent = emitSpy.mock.calls.filter((data) =>
+        data[0].includes(ELEMENT_EVENTS_TO_IFRAME.PUREJS_REQUEST)
+      );
+      const emitCb = emitEvent[0][2];
+      emitCb(deleteResponse);
+
+      let data: DeleteResponse;
+      res.then((res) => {
+        try {
+          data = res;
+          expect(data.records!.length).toBe(1);
+          expect(data.records![0].deleted).toBeTruthy();
+          expect(data.errors).toBeUndefined();
+          done();
+        } catch (err) {
+          done(err);
+        }
+      });
+    } catch (err) {
+      done(err);
+    }
+  });
+
+  test("delete error else", (done) => {
+    try {
+      const res: Promise<DeleteResponse> = skyflow.delete(deleteRecords);
+
+      const frameReayEvent = on.mock.calls.filter((data) =>
+        data[0].includes(ELEMENT_EVENTS_TO_IFRAME.PUREJS_FRAME_READY)
+      );
+      const frameReadyCb = frameReayEvent[1][1];
+      frameReadyCb();
+      const emitEvent = emitSpy.mock.calls.filter((data) =>
+        data[0].includes(ELEMENT_EVENTS_TO_IFRAME.PUREJS_REQUEST)
+      );
+      const emitCb = emitEvent[0][2];
+      emitCb({ error: { message: "No Records Found", code: 404 } });
+
+      res.catch((err: DeleteResponse) => {
+        try {
+          expect(err).toBeDefined();
+          done();
+        } catch (err) {
+          done(err);
+        }
+      });
+    } catch (err) {
+      done(err);
+    }
+  });
+});


### PR DESCRIPTION
This PR adds samples for typescript support as well as updates few consolidated SDK exports, introduces new types and unit tests.

## Why
- We need samples to demonstrate typescript support for JS SDK.
- Some types were missed from consolidated exports.
- Response type for `reveal` was missing, therefore added it.

## Goal
- Proper samples to demonstrate typescript support.
- Consolidated imports all publically exposed interfaces.

## Testing
- Tested manually
- Add unite tests for few core functions in typescript.