### PR TITLE
SK-2130 expiry date validation fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "skyflow-js",
   "preferGlobal": true,
   "analyze": false,
-  "version": "2.3.2",
+  "version": "2.3.2-dev.b478b91",
   "author": "Skyflow",
   "description": "Skyflow JavaScript SDK",
   "homepage": "https://github.com/skyflowapi/skyflow-js",

--- a/src/utils/validators/index.ts
+++ b/src/utils/validators/index.ts
@@ -75,13 +75,15 @@ export const validateExpiryDate = (date: string, format: string) => {
   if (!date.includes('/')) return false;
   const { month, year } = getYearAndMonthBasedOnFormat(date, format);
   if (format.endsWith('YYYY') && year.length !== 4) { return false; }
-  const expiryDate = new Date(`${year}-${month}-01`);
+  const expiryDate = new Date(year, month, 0);
+  expiryDate.setHours(23, 59, 59, 999);
   const today = new Date();
 
   const maxDate = new Date();
   maxDate.setFullYear(today.getFullYear() + 50);
+  maxDate.setMonth(today.getMonth() + 1);
 
-  return expiryDate > today && expiryDate <= maxDate;
+  return expiryDate >= today && expiryDate <= maxDate;
 };
 
 export const validateExpiryYear = (year: string, format: string) => {

--- a/tests/utils/validators.test.js
+++ b/tests/utils/validators.test.js
@@ -65,6 +65,30 @@ describe('Validation card number and Expiry Date', () => {
     expect(validateExpiryDate(expiryDate, "MM/YY")).toBe(false);
   });
 
+  test('validate expired date, MM/YY', () => {
+    const currentDate = new Date();
+    const expiryDate = `${currentDate.getMonth()}/${currentDate.getFullYear().toString().slice(-2)}`;
+    console.log("Current Date: ", currentDate, expiryDate);
+
+    expect(validateExpiryDate(expiryDate, "MM/YY")).toBe(false); 
+  });
+
+  test('validate expiry date with current month, MM/YY', () => {
+    const currentDate = new Date();
+    const expiryDate = `${currentDate.getMonth()+1}/${currentDate.getFullYear().toString().slice(-2)}`;
+    console.log("Current Date: ", currentDate, expiryDate);
+
+    expect(validateExpiryDate(expiryDate, "MM/YY")).toBe(true);
+  });
+
+  test('validate expiry date with next month, MM/YY', () => {
+    const currentDate = new Date();
+    const expiryDate = `${currentDate.getMonth()+2}/${currentDate.getFullYear().toString().slice(-2)}`;
+    console.log("Current Date: ", currentDate, expiryDate);
+
+    expect(validateExpiryDate(expiryDate, "MM/YY")).toBe(true);
+  });
+
   test('empty expirydateformat', () => {
     expect(isValidExpiryDateFormat(null)).toBe(false);
   })


### PR DESCRIPTION
## Why
- Expiry date validation is failing for a credit card expiration date with the value of the current month and year (in this case 06/25).

## Goal
- Validation should pass if the current month and year is entered in the expiry date field

## Testing
- Tested locally 
- Unit testing is also done