### PR TITLE
SK-2101 Make scheme optional in CardMetadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [2.4.1] - 2025-06-19
+### Fixed
+- Make `scheme` optional in `CardMetadata`.
+
 ## [2.4.0] - 2025-06-19
 ### Added
 - Typescript support for public interfaces.

--- a/src/utils/common/index.ts
+++ b/src/utils/common/index.ts
@@ -279,7 +279,7 @@ export interface CollectElementOptions {
 }
 
 export interface CardMetadata {
-  scheme: CardType[],
+  scheme?: CardType[],
 }
 
 export interface CollectElementUpdateOptions {


### PR DESCRIPTION
This PR makes `scheme` property optional in newly added `CardMetadata` interface. 

## Why
- The property `scheme` should be optional in `CardMetadata` as per our README.

## Goal
- New typescript interfaces should be aligned with our existing functionalities
