### PR TITLE
SK-2101/Release/25.6.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [2.4.1] - 2025-06-19
+### Fixed
+- Make `scheme` optional in `CardMetadata`.
+
 ## [2.4.0] - 2025-06-19
 ### Added
 - Typescript support for public interfaces.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "skyflow-js",
   "preferGlobal": true,
   "analyze": false,
-  "version": "2.4.0-dev.8d6e4cd",
+  "version": "2.4.0-dev.93d95e4",
   "author": "Skyflow",
   "description": "Skyflow JavaScript SDK",
   "homepage": "https://github.com/skyflowapi/skyflow-js",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "skyflow-js",
   "preferGlobal": true,
   "analyze": false,
-  "version": "2.4.0",
+  "version": "2.4.0-dev.8d6e4cd",
   "author": "Skyflow",
   "description": "Skyflow JavaScript SDK",
   "homepage": "https://github.com/skyflowapi/skyflow-js",

--- a/src/utils/common/index.ts
+++ b/src/utils/common/index.ts
@@ -282,7 +282,7 @@ export interface CardMetadata {
   scheme?: CardType[],
 }
 
-export interface CollectElementUpdateOptions {
+interface CollectElementCommonProps {
   table?: string,
   column?: string,
   label?: string,
@@ -294,7 +294,12 @@ export interface CollectElementUpdateOptions {
   validations?: IValidationRule[],
   skyflowID?: string,
 }
-export interface CollectElementInput extends CollectElementUpdateOptions {
+
+export interface CollectElementUpdateOptions extends CollectElementCommonProps {
+  cardMetadata?: CardMetadata,
+}
+
+export interface CollectElementInput extends CollectElementCommonProps {
   type: ElementType,
 }
 

--- a/src/utils/common/index.ts
+++ b/src/utils/common/index.ts
@@ -279,7 +279,7 @@ export interface CollectElementOptions {
 }
 
 export interface CardMetadata {
-  scheme: CardType[],
+  scheme?: CardType[],
 }
 
 export interface CollectElementUpdateOptions {


### PR DESCRIPTION
This PR fixes and makes `scheme` optional in `CardMetadata`. It also adds `CardMetadata` to collect element update options.