### PR TITLE
SK-2204/Release/25.7.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [2.4.2] - 2025-07-24
+### Fixed
+- Element state in event listeners for collect elements in `PROD` env.
+
 ## [2.4.1] - 2025-06-19
 ### Fixed
 - Make `scheme` optional in `CardMetadata`.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "skyflow-js",
   "preferGlobal": true,
   "analyze": false,
-  "version": "2.5.0-beta.7-dev.1e8b149",
+  "version": "2.5.0-beta.7-dev.8edd0c9",
   "author": "Skyflow",
   "description": "Skyflow JavaScript SDK",
   "homepage": "https://github.com/skyflowapi/skyflow-js",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "skyflow-js",
   "preferGlobal": true,
   "analyze": false,
-  "version": "2.5.0-beta.5-dev.5abbcf8",
+  "version": "2.5.0-beta.7-dev.1e8b149",
   "author": "Skyflow",
   "description": "Skyflow JavaScript SDK",
   "homepage": "https://github.com/skyflowapi/skyflow-js",

--- a/src/core/internal/frame-element-init.ts
+++ b/src/core/internal/frame-element-init.ts
@@ -32,7 +32,7 @@ export default class FrameElementInit {
 
   constructor() {
     // this.createIframeElement(frameName, label, skyflowID, isRequired);
-    this.context = { logLevel: LogLevel.INFO, env: Env.DEV }; // client level
+    this.context = { logLevel: LogLevel.ERROR, env: Env.PROD }; // client level
     this.containerId = '';
     this.#domForm = document.createElement('form');
     this.#domForm.action = '#';
@@ -50,6 +50,10 @@ export default class FrameElementInit {
     const encodedString = configIndex !== -1 ? decodeURIComponent(url.substring(configIndex + 1)) : '';
     const parsedRecord = encodedString ? JSON.parse(atob(encodedString)) : {};
     this.clientMetaData = parsedRecord.metaData;
+    this.context = {
+      logLevel: this.clientMetaData?.clientJSON?.config?.options?.logLevel || LogLevel.ERROR,
+      env: this.clientMetaData?.clientJSON?.config?.options?.env || Env.PROD,
+    };
     this.group = parsedRecord.record;
     this.containerId = parsedRecord.containerId;
 

--- a/tests/core/internal/iframe-form/iframe-form.test.js
+++ b/tests/core/internal/iframe-form/iframe-form.test.js
@@ -2,7 +2,7 @@
 Copyright (c) 2022 Skyflow, Inc.
 */
 import bus from 'framebus';
-import { COLLECT_FRAME_CONTROLLER, ELEMENT_EVENTS_TO_CLIENT, ELEMENT_EVENTS_TO_IFRAME, ELEMENTS, FRAME_ELEMENT } from '../../../../src/core/constants';
+import { COLLECT_FRAME_CONTROLLER, ELEMENT_EVENTS_TO_CLIENT, ELEMENT_EVENTS_TO_IFRAME, ELEMENTS, ElementType, FRAME_ELEMENT } from '../../../../src/core/constants';
 import { Env, LogLevel, ValidationRuleType } from '../../../../src/utils/common';
 import IFrameFormElement from '../../../../src/core/internal/iframe-form'
 import * as busEvents from '../../../../src/utils/bus-events';
@@ -124,6 +124,142 @@ describe('test iframeFormelement', () => {
         });
         element.setValue('2020-12-30')
         expect(element.getValue()).toBe('2020-12-30')
+    });
+
+    test('iframeFormElement element state value for collect elements in PROD env', () => {
+        const elementsList = [
+            {
+                element: test_collect_element,
+                type: ElementType.CARD_NUMBER,
+                input: '4111111111111111',
+                expected:'41111111XXXXXXXX'
+            },
+            {
+                element: collect_element,
+                type: ElementType.CVV,
+                input: '1234',
+                expected: undefined
+            },
+            {
+                element: test_collect_element,
+                type: ElementType.CARDHOLDER_NAME,
+                input: 'john doe',
+                expected: undefined
+            },
+            {
+                element: test_collect_element,
+                type: ElementType.EXPIRATION_DATE,
+                input: '12/30',
+                format: 'MM/YY',
+                expected: undefined,
+            },
+            {
+                element: test_collect_element,
+                type: ElementType.EXPIRATION_MONTH,
+                input: '11',
+                expected: undefined
+            },
+            {
+                element: test_collect_element,
+                type: ElementType.EXPIRATION_YEAR,
+                input: '29',
+                expected: undefined
+            },
+            {
+                element: test_collect_element,
+                type: ElementType.PIN,
+                input: '2912',
+                expected: undefined
+            },
+            {
+                element: test_collect_element,
+                type: ElementType.INPUT_FIELD,
+                input: '212-61-2465',
+                expected: undefined
+            },
+        ];
+
+        for (const element of elementsList) {
+            const iframeElement = new IFrameFormElement(element.element, element.type, {}, context);
+            Object.defineProperty(iframeElement, 'fieldType', {
+                get: () => element.type,
+                set: () => {}
+            });
+            if (element.format !== undefined) {
+                iframeElement.setFormat(element.format);
+            }
+            iframeElement.setValue(element.input);
+            console.log(element.type);
+            expect(iframeElement.getStatus().value).toBe(element.expected);
+        }
+    });
+
+    test('iframeFormElement element state value for card number in DEV env', () => {
+        const elementsList = [
+            {
+                element: test_collect_element,
+                type: ElementType.CARD_NUMBER,
+                input: '4111111111111111',
+                expected:'4111111111111111'
+            },
+            {
+                element: collect_element,
+                type: ElementType.CVV,
+                input: '1234',
+                expected: '1234'
+            },
+            {
+                element: test_collect_element,
+                type: ElementType.CARDHOLDER_NAME,
+                input: 'john doe',
+                expected: 'john doe'
+            },
+            {
+                element: test_collect_element,
+                type: ElementType.EXPIRATION_DATE,
+                input: '12/30',
+                format: 'MM/YY',
+                expected: '12/30',
+            },
+            {
+                element: test_collect_element,
+                type: ElementType.EXPIRATION_MONTH,
+                input: '11',
+                expected: '11'
+            },
+            {
+                element: test_collect_element,
+                type: ElementType.EXPIRATION_YEAR,
+                input: '29',
+                expected: '29'
+            },
+            {
+                element: test_collect_element,
+                type: ElementType.PIN,
+                input: '2912',
+                expected: '2912'
+            },
+            {
+                element: test_collect_element,
+                type: ElementType.INPUT_FIELD,
+                input: '212-61-2465',
+                expected: '212-61-2465'
+            },
+        ];
+
+        for (const element of elementsList) {
+            const iframeElement = new IFrameFormElement(element.element, element.type, {}, {...context, env: Env.DEV});
+            Object.defineProperty(iframeElement, 'fieldType', {
+                get: () => element.type,
+                set: () => {}
+            });
+            if (element.format !== undefined) {
+                iframeElement.setFormat(element.format);
+            }
+            iframeElement.setValue(element.input);
+            console.log(element.type);
+            expect(iframeElement.getStatus().value).toBe(element.expected);
+        }
     });
 
     test('iframeFormelement should throw error for sensitive', () => {

--- a/tests/core/internal/iframe-form/iframe-form.test.js
+++ b/tests/core/internal/iframe-form/iframe-form.test.js
@@ -189,12 +189,11 @@ describe('test iframeFormelement', () => {
                 iframeElement.setFormat(element.format);
             }
             iframeElement.setValue(element.input);
-            console.log(element.type);
             expect(iframeElement.getStatus().value).toBe(element.expected);
         }
     });
 
-    test('iframeFormElement element state value for card number in DEV env', () => {
+    test('iframeFormElement element state value for collect elements in DEV env', () => {
         const elementsList = [
             {
                 element: test_collect_element,
@@ -257,7 +256,6 @@ describe('test iframeFormelement', () => {
                 iframeElement.setFormat(element.format);
             }
             iframeElement.setValue(element.input);
-            console.log(element.type);
             expect(iframeElement.getStatus().value).toBe(element.expected);
         }
     });


### PR DESCRIPTION
This PR fixes a bug where incorrect values were being sent in listeners for `PROD` environment. 

## Why
- There was a bug where incorrect values were being sent to element listeners in state in `PROD` environment.

## Goal
- For `PROD` environment, `CARD_NUMBER` element should receive masked value and all other elements should receive empty values.

## Testing
- Manually tested the changes.
- Added unit tests to check value returned in element state for collect elements in different ENVs.
