### PR TITLE
SK-2186:Fix BIN Lookup for Card Numbers with Formats Other Than Spaces in JS SDK

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "skyflow-js",
   "preferGlobal": true,
   "analyze": false,
-  "version": "2.5.0-beta.8-dev.32d07de",
+  "version": "2.5.0-beta.8-dev.589a8e5",
   "author": "Skyflow",
   "description": "Skyflow JavaScript SDK",
   "homepage": "https://github.com/skyflowapi/skyflow-js",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "skyflow-js",
   "preferGlobal": true,
   "analyze": false,
-  "version": "2.4.2",
+  "version": "2.5.0-beta.8-dev.32d07de",
   "author": "Skyflow",
   "description": "Skyflow JavaScript SDK",
   "homepage": "https://github.com/skyflowapi/skyflow-js",

--- a/samples/using-script-tag/card-branch-choice.html
+++ b/samples/using-script-tag/card-branch-choice.html
@@ -189,7 +189,6 @@
             const collectButton = document.getElementById('collectPCIData');
             if (collectButton) {
                 collectButton.addEventListener('click', () => {
-                    cardNumberElement.mount("#collectCardNumber")
                     const collectResponse = collectContainer.collect();
 
                     collectResponse

--- a/src/utils/helpers/index.ts
+++ b/src/utils/helpers/index.ts
@@ -70,7 +70,7 @@ export const appendMonthTwoDigitYears = (value) => {
 export const getReturnValue = (value: string | Blob, element: string, doesReturnValue: boolean) => {
   if (typeof value === 'string') {
     if (element === ElementType.CARD_NUMBER) {
-      value = value && value.replace(/\s/g, '');
+      value = value && value.replace(/[\s-]/g, '');
       if (!doesReturnValue) {
         const cardType = detectCardType(value);
         const threshold = cardType !== CardType.DEFAULT && cardType === CardType.AMEX ? 6 : 8;

--- a/tests/utils/helpers.test.js
+++ b/tests/utils/helpers.test.js
@@ -79,6 +79,8 @@ describe('bin data for for AMEX card number element type on CHANGE event', () =>
     expect(getReturnValue("02", ElementType.EXPIRATION_MONTH, false)).toBe(undefined)
     expect(getReturnValue("2025", ElementType.EXPIRATION_YEAR, false)).toBe(undefined)
     expect(getReturnValue("1234", ElementType.PIN, false)).toBe(undefined)
+    expect(getReturnValue('4111 1111 1111 1111', ElementType.CARD_NUMBER, true)).toBe('4111111111111111');
+    expect(getReturnValue('4111-1111-1111-1111', ElementType.CARD_NUMBER, true)).toBe('4111111111111111');
   })
   test("in DEV return data for all elements", () => {
     expect(getReturnValue("3782 822463 10005", ElementType.CARD_NUMBER, true)).toBe("378282246310005")


### PR DESCRIPTION
**Why**

- The BIN lookup was failing when card numbers were formatted with characters other than spaces.

**Outcome**

- Card numbers are now normalized to remove all non-digit characters before performing BIN lookup. This ensures consistent behavior regardless of formatting style.