### PR TITLE
SK-2254: Fix 0px Height Issue in Composable Container and Upgrade File Upload to v2 API

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "skyflow-js",
   "preferGlobal": true,
   "analyze": false,
-  "version": "2.5.0-beta.9-dev.ff71850",
+  "version": "2.5.0-beta.9-dev.3d1ed74",
   "author": "Skyflow",
   "description": "Skyflow JavaScript SDK",
   "homepage": "https://github.com/skyflowapi/skyflow-js",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "skyflow-js",
   "preferGlobal": true,
   "analyze": false,
-  "version": "2.5.0-beta.9",
+  "version": "2.5.0-beta.9-dev.99fa815",
   "author": "Skyflow",
   "description": "Skyflow JavaScript SDK",
   "homepage": "https://github.com/skyflowapi/skyflow-js",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "skyflow-js",
   "preferGlobal": true,
   "analyze": false,
-  "version": "2.5.0-beta.9-dev.99fa815",
+  "version": "2.5.0-beta.9-dev.fcfbd99",
   "author": "Skyflow",
   "description": "Skyflow JavaScript SDK",
   "homepage": "https://github.com/skyflowapi/skyflow-js",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "skyflow-js",
   "preferGlobal": true,
   "analyze": false,
-  "version": "2.5.0-beta.9-dev.fcfbd99",
+  "version": "2.5.0-beta.9-dev.ff71850",
   "author": "Skyflow",
   "description": "Skyflow JavaScript SDK",
   "homepage": "https://github.com/skyflowapi/skyflow-js",

--- a/src/core/external/collect/collect-element.ts
+++ b/src/core/external/collect/collect-element.ts
@@ -207,18 +207,20 @@ class CollectElement extends SkyflowElement {
     if(domElement instanceof HTMLElement){
       this.resizeObserver = new ResizeObserver(() => {
         const iframeElements = domElement.getElementsByTagName('iframe');
-        for (let i = 0; i < iframeElements.length; i++) {
-          const iframeElement = iframeElements[i];
-          if (
-            iframeElement.name === this.#iframe.name &&
-            iframeElement.contentWindow
-          ) {
-            iframeElement?.contentWindow?.postMessage(
-              {
-                name: ELEMENT_EVENTS_TO_CLIENT.HEIGHT + this.#iframe.name,
-              },
-              properties.IFRAME_SECURE_ORIGIN
-            );
+        if (iframeElements && iframeElements.length > 0) {
+          for (let i = 0; i < iframeElements.length; i++) {
+            const iframeElement = iframeElements[i];
+            if (
+              iframeElement.name === this.#iframe.name &&
+              iframeElement.contentWindow
+            ) {
+              iframeElement?.contentWindow?.postMessage(
+                {
+                  name: ELEMENT_EVENTS_TO_CLIENT.HEIGHT + this.#iframe.name,
+                },
+                properties.IFRAME_SECURE_ORIGIN
+              );
+            }
           }
         }
       });

--- a/src/core/external/collect/collect-element.ts
+++ b/src/core/external/collect/collect-element.ts
@@ -206,12 +206,19 @@ class CollectElement extends SkyflowElement {
 
     if(domElement instanceof HTMLElement){
       this.resizeObserver = new ResizeObserver(() => {
-        if (domElement.getElementsByTagName('iframe')[0]?.contentWindow) {
-          const iframeElement = domElement.getElementsByTagName('iframe')[0]
-          if(iframeElement.name === this.#iframe.name){
-            iframeElement?.contentWindow?.postMessage({
-            name: ELEMENT_EVENTS_TO_CLIENT.HEIGHT + this.#iframe.name,
-          }, properties.IFRAME_SECURE_ORIGIN);
+        const iframeElements = domElement.getElementsByTagName('iframe');
+        for (let i = 0; i < iframeElements.length; i++) {
+          const iframeElement = iframeElements[i];
+          if (
+            iframeElement.name === this.#iframe.name &&
+            iframeElement.contentWindow
+          ) {
+            iframeElement?.contentWindow?.postMessage(
+              {
+                name: ELEMENT_EVENTS_TO_CLIENT.HEIGHT + this.#iframe.name,
+              },
+              properties.IFRAME_SECURE_ORIGIN
+            );
           }
         }
       });

--- a/src/core/external/reveal/composable-reveal-internal.ts
+++ b/src/core/external/reveal/composable-reveal-internal.ts
@@ -192,18 +192,20 @@ class ComposableRevealInternalElement extends SkyflowElement {
     if(domElementSelector instanceof HTMLElement){
       this.resizeObserver = new ResizeObserver(() => {
         const iframeElements = domElementSelector.getElementsByTagName('iframe');
-        for (let i = 0; i < iframeElements.length; i++) {
-          const iframeElement = iframeElements[i];
-          if (
-            iframeElement.name === this.#iframe.name &&
-            iframeElement.contentWindow
-          ) {
-            iframeElement?.contentWindow?.postMessage(
-              {
-                name: ELEMENT_EVENTS_TO_CLIENT.HEIGHT + this.#iframe.name,
-              },
-              properties.IFRAME_SECURE_ORIGIN
-            );
+        if (iframeElements && iframeElements.length > 0) {
+            for (let i = 0; i < iframeElements.length; i++) {
+            const iframeElement = iframeElements[i];
+            if (
+              iframeElement.name === this.#iframe.name &&
+              iframeElement.contentWindow
+            ) {
+              iframeElement?.contentWindow?.postMessage(
+                {
+                  name: ELEMENT_EVENTS_TO_CLIENT.HEIGHT + this.#iframe.name,
+                },
+                properties.IFRAME_SECURE_ORIGIN
+              );
+            }
           }
         }
       });

--- a/src/core/external/reveal/composable-reveal-internal.ts
+++ b/src/core/external/reveal/composable-reveal-internal.ts
@@ -191,12 +191,19 @@ class ComposableRevealInternalElement extends SkyflowElement {
 
     if(domElementSelector instanceof HTMLElement){
       this.resizeObserver = new ResizeObserver(() => {
-        if (domElementSelector.getElementsByTagName('iframe')[0]?.contentWindow) {
-          const iframeElement = domElementSelector.getElementsByTagName('iframe')[0]
-          if(iframeElement.name === this.#iframe.name){
-            iframeElement?.contentWindow?.postMessage({
-            name: ELEMENT_EVENTS_TO_CLIENT.HEIGHT + this.#iframe.name,
-          }, properties.IFRAME_SECURE_ORIGIN);
+        const iframeElements = domElementSelector.getElementsByTagName('iframe');
+        for (let i = 0; i < iframeElements.length; i++) {
+          const iframeElement = iframeElements[i];
+          if (
+            iframeElement.name === this.#iframe.name &&
+            iframeElement.contentWindow
+          ) {
+            iframeElement?.contentWindow?.postMessage(
+              {
+                name: ELEMENT_EVENTS_TO_CLIENT.HEIGHT + this.#iframe.name,
+              },
+              properties.IFRAME_SECURE_ORIGIN
+            );
           }
         }
       });

--- a/src/core/external/reveal/composable-reveal-internal.ts
+++ b/src/core/external/reveal/composable-reveal-internal.ts
@@ -54,6 +54,8 @@ class ComposableRevealInternalElement extends SkyflowElement {
 
   #elementId: string;
 
+  resizeObserver: ResizeObserver | null;
+
   #readyToMount: boolean = false;
 
   #eventEmitter: EventEmitter;
@@ -83,6 +85,7 @@ class ComposableRevealInternalElement extends SkyflowElement {
     super();
     this.#elementId = elementId;
     this.#metaData = metaData;
+    this.resizeObserver = null;
     this.#clientId = this.#metaData?.uuid;
     this.#isSingleElementAPI = isSingleElementAPI;
     this.#recordData = recordGroup;
@@ -185,12 +188,35 @@ class ComposableRevealInternalElement extends SkyflowElement {
     if (!domElementSelector) {
       throw new SkyflowError(SKYFLOW_ERROR_CODE.EMPTY_ELEMENT_IN_MOUNT, ['RevealElement'], true);
     }
+
+    if(domElementSelector instanceof HTMLElement){
+      this.resizeObserver = new ResizeObserver(() => {
+        if (domElementSelector.getElementsByTagName('iframe')[0]?.contentWindow) {
+          const iframeElement = domElementSelector.getElementsByTagName('iframe')[0]
+          if(iframeElement.name === this.#iframe.name){
+            iframeElement?.contentWindow?.postMessage({
+            name: ELEMENT_EVENTS_TO_CLIENT.HEIGHT + this.#iframe.name,
+          }, properties.IFRAME_SECURE_ORIGIN);
+          }
+        }
+      });
+    }
+
     updateMetricObjectValue(this.#elementId, METRIC_TYPES.DIV_ID, domElementSelector);
     if (
       this.#metaData?.clientJSON?.config?.options?.trackMetrics
       && this.#metaData.clientJSON.config?.options?.trackingKey
     ) {
       pushElementEventWithTimeout(this.#elementId);
+    }
+
+    if (typeof domElementSelector === 'string') {
+      const targetElement = document.querySelector(domElementSelector);
+      if (targetElement) {
+        this.resizeObserver?.observe(targetElement);
+      }
+    } else if (domElementSelector instanceof HTMLElement) {
+      this.resizeObserver?.observe(domElementSelector);
     }
 
     this.#readyToMount = true;

--- a/src/utils/validators/index.ts
+++ b/src/utils/validators/index.ts
@@ -560,10 +560,6 @@ export const validateCollectElementInput = (input: CollectElementInput, logLevel
   if (Object.prototype.hasOwnProperty.call(input, 'skyflowID') && !(typeof input.skyflowID === 'string')) {
     throw new SkyflowError(SKYFLOW_ERROR_CODE.INVALID_SKYFLOWID_IN_COLLECT, [], true);
   }
-  if (input.type === ElementType.FILE_INPUT
-    && !Object.keys(input).includes('skyflowID')) {
-    throw new SkyflowError(SKYFLOW_ERROR_CODE.MISSING_SKYFLOWID_IN_COLLECT, [], true);
-  }
 };
 
 export const validateUpsertOptions = (upsertOptions) => {


### PR DESCRIPTION
**Why**

- The composable container’s height is intermittently being set to 0px, causing rendering issues.

- The file upload is currently using the v1 API. It should be updated to v2, where the skyflowID is optional.

**Outcome**

- The composable container height should be rendered correctly and should not default to 0px.

- File upload should work with the v2 API, supporting optional skyflowID.