### PR TITLE
SK-2733: Migrate file upload api from v1 to v2 in collect elements

### DIFF
--- a/src/core-utils/collect.ts
+++ b/src/core-utils/collect.ts
@@ -161,7 +161,10 @@ export const constructFinalUpdateRecordResponse = (
   };
 };
 
-export const constructUploadResponse = (response) => response;
+export const constructUploadResponse = (response) => {
+  const data = typeof response === 'string' ? JSON.parse(response) : response;
+  return JSON.stringify({ skyflow_id: data.skyflowID }) as any;
+};
 
 const keyify = (obj, prefix = '') => Object.keys(obj).reduce((res: any, el) => {
   if (Array.isArray(obj[el])) {

--- a/src/core/internal/skyflow-frame/skyflow-frame-controller.ts
+++ b/src/core/internal/skyflow-frame/skyflow-frame-controller.ts
@@ -901,6 +901,9 @@ class SkyflowFrameController {
 
     const value: Blob = Object.values(fileUploadObject)[0] as Blob;
 
+    formData.append('columnName', column);
+    formData.append('tableName', tableName ?? '');
+
     if (preserveFileName) {
       const isValidFileName = vaildateFileName(state.value.name);
       if (!isValidFileName) {
@@ -908,10 +911,14 @@ class SkyflowFrameController {
           new SkyflowError(SKYFLOW_ERROR_CODE.INVALID_FILE_NAME, [], true),
         );
       }
-      formData.append(column, value);
+      formData.append('file', value);
     } else {
       const generatedFileName = generateUploadFileName(state.value.name);
-      formData.append(column, new File([value], generatedFileName, { type: state.value.type }));
+      formData.append('file', new File([value], generatedFileName, { type: state.value.type }));
+    }
+
+    if (skyflowID) {
+      formData.append('skyflowID', skyflowID);
     }
 
     const client = this.#client;
@@ -923,7 +930,7 @@ class SkyflowFrameController {
           .request({
             body: formData,
             requestMethod: 'POST',
-            url: `${client.config.vaultURL}/v1/vaults/${client.config.vaultID}/${tableName}/${skyflowID}/files`,
+            url: `${client.config.vaultURL}/v2/vaults/${client.config.vaultID}/files/upload`,
             headers: {
               authorization: `Bearer ${authToken}`,
               'content-type': 'multipart/form-data',

--- a/tests/core/internal/skyflow-frame/skyflow-frame-controller-upload-tokenize.test.js
+++ b/tests/core/internal/skyflow-frame/skyflow-frame-controller-upload-tokenize.test.js
@@ -490,8 +490,54 @@ describe('Uploading files to the vault', () => {
         done();
       }, 1000);
     });
+
+    test('should upload file with preserveFileName false and skyflowID set', (done) => {
+      testValue.iFrameFormElement.preserveFileName = false;
+      testValue.iFrameFormElement.skyflowID = 'test-skyflow-id';
+      windowSpy.mockImplementation(()=>({
+        frames:{
+          'element:FILE_INPUT:ID:CONTAINER-ID:ERROR:':{document:{
+              getElementById:()=>(testValue)
+          }}
+        }
+      }));
+      const clientReq = jest.fn(() => Promise.resolve({ skyflowID: 'file-upload-skyflow-id' }));
+      jest.spyOn(clientModule, 'fromJSON').mockImplementation(() => ({
+        ...clientData.client,
+        request: clientReq,
+        toJSON: toJson
+      }));
+
+      SkyflowFrameController.init();
+
+      const emitEventName = emitSpy.mock.calls[1][0];
+      const emitCb = emitSpy.mock.calls[1][2];
+      expect(emitEventName).toBe(ELEMENT_EVENTS_TO_IFRAME.SKYFLOW_FRAME_CONTROLLER_READY);
+      emitCb(clientData);
+
+      const onCb = on.mock.calls[1][1];
+      const data = {
+        type: COLLECT_TYPES.FILE_UPLOAD,
+        elementIds: ['element:FILE_INPUT:ID'],
+        containerId: 'CONTAINER-ID',
+      };
+      const cb2 = jest.fn();
+
+      onCb(data, cb2);
+
+      setTimeout(() => {
+        expect(cb2).toHaveBeenCalled();
+        expect(cb2.mock.calls[0][0].fileUploadResponse).toBeDefined();
+        expect(cb2.mock.calls[0][0].fileUploadResponse.length).toBe(1);
+        const parsedResponse = JSON.parse(cb2.mock.calls[0][0].fileUploadResponse[0]);
+        expect(parsedResponse.skyflow_id).toBe('file-upload-skyflow-id');
+        const requestArgs = clientReq.mock.calls[0][0];
+        expect(requestArgs.body.get('skyflowID')).toBe('test-skyflow-id');
+        done();
+      }, 1000);
+    });
 });
-  
+
 describe('SkyflowFrameController - tokenize function', () => {
   let emitSpy;
   let targetSpy;

--- a/tests/core/internal/skyflow-frame/skyflow-frame-controller-upload-tokenize.test.js
+++ b/tests/core/internal/skyflow-frame/skyflow-frame-controller-upload-tokenize.test.js
@@ -103,7 +103,7 @@ describe('Uploading files to the vault', () => {
         }
       }));
       const clientReq = jest.fn(() => Promise.resolve(
-        JSON.stringify({ skyflow_id:"file-upload-skyflow-id" })));
+        JSON.stringify({ skyflowID: "file-upload-skyflow-id", fileMetadata: { fileName: "test-file.txt", fileSize: 1024, fileType: "file" } })));
       jest.spyOn(clientModule, 'fromJSON').mockImplementation(() => ({
         ...clientData.client,
         request: clientReq,
@@ -314,10 +314,10 @@ describe('Uploading files to the vault', () => {
     
       // Mock client request to succeed for first file and fail for second
       const clientReq = jest.fn((request) => {
-        if (request.body.get('file2')) {
+        if (request.body.get('columnName') === 'file2') {
           return Promise.reject({ error: { code: 400, description: "Upload failed" } });
         } else {
-          return Promise.resolve(JSON.stringify({ skyflow_id: "success-file-id" }));
+          return Promise.resolve(JSON.stringify({ skyflowID: "success-file-id", fileMetadata: { fileName: "test-file.txt", fileSize: 1024, fileType: "file" } }));
         }
       });
     

--- a/tests/core/internal/skyflow-frame/skyflow-frame-controller-upload-tokenize.test.ts
+++ b/tests/core/internal/skyflow-frame/skyflow-frame-controller-upload-tokenize.test.ts
@@ -246,7 +246,7 @@ describe("Uploading files to the vault", () => {
       },
     }));
     const clientReq = jest.fn(() =>
-      Promise.resolve(JSON.stringify({ skyflow_id: "file-upload-skyflow-id" }))
+      Promise.resolve(JSON.stringify({ skyflowID: "file-upload-skyflow-id", fileMetadata: { fileName: "test-file.txt", fileSize: 1024, fileType: "file" } }))
     );
     jest.spyOn(clientModule, "fromJSON").mockImplementation(
       () =>
@@ -311,13 +311,13 @@ describe("Uploading files to the vault", () => {
 
     // Mock client request to succeed for first file and fail for second
     const clientReq = jest.fn((request) => {
-      if (request.body.get("file2")) {
+      if (request.body.get("columnName") === "file2") {
         return Promise.reject({
           error: { code: 400, description: "Upload failed" },
         });
       } else {
         return Promise.resolve(
-          JSON.stringify({ skyflow_id: "success-file-id" })
+          JSON.stringify({ skyflowID: "success-file-id", fileMetadata: { fileName: "test-file.txt", fileSize: 1024, fileType: "file" } })
         );
       }
     });

--- a/tests/core/internal/skyflow-frame/skyflow-frame-controller-upload-tokenize.test.ts
+++ b/tests/core/internal/skyflow-frame/skyflow-frame-controller-upload-tokenize.test.ts
@@ -427,6 +427,62 @@ describe("Uploading files to the vault", () => {
       done();
     }, 1000);
   });
+
+  test("should upload file with preserveFileName false and skyflowID set", (done) => {
+    testValue.iFrameFormElement.preserveFileName = false;
+    testValue.iFrameFormElement.skyflowID = "test-skyflow-id";
+    windowSpy.mockImplementation(() => ({
+      frames: {
+        "element:FILE_INPUT:ID:CONTAINER-ID:ERROR:": {
+          document: {
+            getElementById: () => testValue,
+          },
+        },
+      },
+    }));
+    const clientReq = jest.fn(() =>
+      Promise.resolve({ skyflowID: "file-upload-skyflow-id" })
+    );
+    jest.spyOn(clientModule, "fromJSON").mockImplementation(
+      () =>
+        ({
+          ...clientData.client,
+          request: clientReq,
+          toJSON: toJson,
+        } as unknown as Client)
+    );
+
+    SkyflowFrameController.init(mockUuid);
+
+    const emitEventName = emitSpy.mock.calls[1][0];
+    const emitCb = emitSpy.mock.calls[1][2];
+    expect(emitEventName).toBe(
+      ELEMENT_EVENTS_TO_IFRAME.SKYFLOW_FRAME_CONTROLLER_READY + mockUuid
+    );
+    emitCb(clientData);
+
+    const onCb = on.mock.calls[1][1];
+    const data: UploadFileDataInput = {
+      type: COLLECT_TYPES.FILE_UPLOAD,
+      elementIds: ["element:FILE_INPUT:ID"],
+      containerId: "CONTAINER-ID",
+    };
+    const cb2 = jest.fn();
+
+    onCb(data, cb2);
+
+    setTimeout(() => {
+      expect(cb2).toHaveBeenCalled();
+      expect(cb2.mock.calls[0][0].fileUploadResponse).toBeDefined();
+      expect(cb2.mock.calls[0][0].fileUploadResponse.length).toBe(1);
+      const parsedResponse = JSON.parse(cb2.mock.calls[0][0].fileUploadResponse[0]);
+      expect(parsedResponse.skyflow_id).toBe("file-upload-skyflow-id");
+      expect(clientReq).toHaveBeenCalled();
+      const requestArgs = (clientReq.mock.calls as any[][])[0][0];
+      expect(requestArgs.body.get("skyflowID")).toBe("test-skyflow-id");
+      done();
+    }, 1000);
+  });
 });
 
 describe("SkyflowFrameController - tokenize function", () => {


### PR DESCRIPTION
**Why**
- Collect elements currently use the v1 file upload API, while composable has already migrated to v2.
- Aligning both to v2 ensures consistency and keeps us up to date with the latest API standards.

**Outcome**
- Collect elements now use the v2 file upload API, consistent with composable elements.
- File upload is now supported even when no Skyflow ID is provided, creating a new record automatically.
