### PR TITLE
SK-3004:Update common-release.yml for beta release.

### DIFF
--- a/.github/workflows/common-release.yml
+++ b/.github/workflows/common-release.yml
@@ -110,16 +110,16 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ secrets.AWS_REGION }}
 
-      - name: Set Latest Tag
-        run: |
-          mkdir tags
-          echo "v${{ env.RELEASE_VERSION }}" > tags/latest
+      # - name: Set Latest Tag
+      #   run: |
+      #     mkdir tags
+      #     echo "v${{ env.RELEASE_VERSION }}" > tags/latest
 
-      - name: Deploy Latest Tag to S3
-        run: aws s3 cp --recursive tags s3://${{ secrets.AWS_BUCKET_NAME }}/
+      # - name: Deploy Latest Tag to S3
+      #   run: aws s3 cp --recursive tags s3://${{ secrets.AWS_BUCKET_NAME }}/
 
-      - name: Remove Latest Tag
-        run: rm -rf tags
+      # - name: Remove Latest Tag
+      #   run: rm -rf tags
 
       - name: Deploy to S3
         run: |
@@ -136,7 +136,7 @@ jobs:
       - name: Publish SDK
         run: |
           if [ "${{ inputs.TAG }}" == "beta" ]; then
-            npm publish --tag ${{ inputs.TAG }}
+            npm publish --tag v${{  env.RELEASE_VERSION }}
           elif [ "${{ inputs.TAG }}" == "internal" ]; then
             curl -u ${{ secrets.JFROG_USERNAME }}:${{ secrets.JFROG_PASSWORD }} https://prekarilabs.jfrog.io/prekarilabs/api/npm/auth/ > ~/.npmrc
             npm config set registry https://prekarilabs.jfrog.io/prekarilabs/api/npm/npm/


### PR DESCRIPTION
## Prevent beta releases from overwriting the `latest`/`beta` pointers

### What changed
In `.github/workflows/common-release.yml`:

1. **Disabled the "latest" tag deployment to S3** — commented out the *Set Latest Tag*, *Deploy Latest Tag to S3*, and *Remove Latest Tag* steps. Releases no longer push a `latest` file to the S3 bucket, so a beta release won't repoint the hosted CDN `latest` build.

2. **Beta npm publish now uses a version-specific dist-tag** — changed the beta publish from `npm publish --tag beta` to `npm publish --tag v<RELEASE_VERSION>`. Each beta is published under its own unique tag instead of overwriting the shared `beta` dist-tag.

### Why
Previously every beta release overwrote the shared `latest`/`beta` pointers, meaning the newest beta always became *the* beta build consumers resolved to. This change keeps each beta isolated under its own version tag and stops betas from mutating the `latest` pointer, so publishing a new beta no longer clobbers the existing latest beta build.

### Impact
- No functional change to `public`/`internal` release flows.
- Beta consumers must now install a specific `v<version>` tag rather than relying on a floating `beta` tag.
