### PR TITLE
SK-2977:Add beta build disclaimer banner to README on release

### DIFF
--- a/.github/workflows/common-release.yml
+++ b/.github/workflows/common-release.yml
@@ -88,6 +88,7 @@ jobs:
           git config user.email ${{ github.actor }}@users.noreply.github.com
           git checkout ${{ env.branch_name }}
           git add package.json
+          git add README.md
           git commit -m "[AUTOMATED] Release - ${{ env.RELEASE_VERSION }}"
           git push origin ${{ env.branch_name }} -f
 

--- a/scripts/bump_version.sh
+++ b/scripts/bump_version.sh
@@ -6,6 +6,7 @@ then
 	echo "Bumping package version to $1"
 
 	sed -E "s/\"version\": .+/\"version\": \"$SEMVER\",/g" package.json > tempfile && cat tempfile > package.json && rm -f tempfile
+	./scripts/toggle_beta_banner.sh README.md "$SEMVER"
 	echo --------------------------
 	echo "Done, Package now at $1"
 

--- a/scripts/toggle_beta_banner.sh
+++ b/scripts/toggle_beta_banner.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+README="$1"
+VERSION="$2"
+
+MARKER_START="<!-- SKYFLOW-BETA-DISCLAIMER:START -->"
+MARKER_END="<!-- SKYFLOW-BETA-DISCLAIMER:END -->"
+
+TEMP_FILE=$(mktemp)
+
+# Check if version is beta
+if [[ "$VERSION" =~ beta ]]; then
+    # Remove existing banner if present
+    if grep -q -F "$MARKER_START" "$README"; then
+        sed "/$MARKER_START/,/$MARKER_END/d" "$README" > "$TEMP_FILE"
+    else
+        cp "$README" "$TEMP_FILE"
+    fi
+
+    # Insert banner after the first line (title)
+    awk "NR==1 {print; print \"$MARKER_START\"; print \"> **Beta Disclaimer:** This is a beta release. Features may change before general availability.\"; print \"$MARKER_END\"; next} 1" "$TEMP_FILE" > "$README"
+else
+    # Remove banner if present
+    if grep -q -F "$MARKER_START" "$README"; then
+        sed "/$MARKER_START/,/$MARKER_END/d" "$README" > "$TEMP_FILE"
+        mv "$TEMP_FILE" "$README"
+    fi
+fi
+
+rm -f "$TEMP_FILE"

--- a/scripts/toggle_beta_banner.sh
+++ b/scripts/toggle_beta_banner.sh
@@ -9,8 +9,8 @@ MARKER_END="<!-- SKYFLOW-BETA-DISCLAIMER:END -->"
 
 TEMP_FILE=$(mktemp)
 
-# Check if version is beta
-if [[ "$VERSION" =~ beta ]]; then
+# Check if version is beta (matches -beta.N pattern)
+if [[ "$VERSION" =~ -beta\.[0-9]+ ]]; then
     # Remove existing banner if present
     if grep -q -F "$MARKER_START" "$README"; then
         sed "/$MARKER_START/,/$MARKER_END/d" "$README" > "$TEMP_FILE"
@@ -19,7 +19,7 @@ if [[ "$VERSION" =~ beta ]]; then
     fi
 
     # Insert banner after the first line (title)
-    awk "NR==1 {print; print \"$MARKER_START\"; print \"> **Beta Disclaimer:** This is a beta release. Features may change before general availability.\"; print \"$MARKER_END\"; next} 1" "$TEMP_FILE" > "$README"
+    awk "NR==1 {print; print \"$MARKER_START\"; print \"> ⚠️ **Beta release — not for production use.** This is a pre-release build provided for early testing and feedback. It has not completed Skyflow's General Availability (GA) validation, its API may change before the stable release, and it is not covered by production SLAs or support commitments. Do not deploy beta builds to production environments.\"; print \"$MARKER_END\"; next} 1" "$TEMP_FILE" > "$README"
 else
     # Remove banner if present
     if grep -q -F "$MARKER_START" "$README"; then

--- a/scripts/toggle_beta_banner.test.sh
+++ b/scripts/toggle_beta_banner.test.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TOGGLE="$SCRIPT_DIR/toggle_beta_banner.sh"
+FIXTURE="$(mktemp)"
+MARKER_START="<!-- SKYFLOW-BETA-DISCLAIMER:START -->"
+
+fail() {
+    echo "FAIL: $1"
+    rm -f "$FIXTURE"
+    exit 1
+}
+
+cat > "$FIXTURE" <<'EOF'
+# skyflow-js
+Skyflow's JavaScript SDK intro text.
+EOF
+
+"$TOGGLE" "$FIXTURE" "2.9.0-beta.1"
+[ "$(grep -c -F "$MARKER_START" "$FIXTURE")" -eq 1 ] || fail "banner not inserted for beta version"
+
+"$TOGGLE" "$FIXTURE" "2.9.0-beta.1"
+[ "$(grep -c -F "$MARKER_START" "$FIXTURE")" -eq 1 ] || fail "banner duplicated on repeat run"
+
+"$TOGGLE" "$FIXTURE" "2.9.0"
+[ "$(grep -c -F "$MARKER_START" "$FIXTURE")" -eq 0 ] || fail "banner not removed for GA version"
+
+grep -qF "JavaScript SDK intro text." "$FIXTURE" || fail "original README content lost"
+
+rm -f "$FIXTURE"
+echo "PASS: toggle_beta_banner.sh"

--- a/scripts/toggle_beta_banner.test.sh
+++ b/scripts/toggle_beta_banner.test.sh
@@ -19,12 +19,15 @@ EOF
 
 "$TOGGLE" "$FIXTURE" "2.9.0-beta.1"
 [ "$(grep -c -F "$MARKER_START" "$FIXTURE")" -eq 1 ] || fail "banner not inserted for beta version"
+grep -qF "not for production use" "$FIXTURE" || fail "banner content missing correct text"
 
 "$TOGGLE" "$FIXTURE" "2.9.0-beta.1"
 [ "$(grep -c -F "$MARKER_START" "$FIXTURE")" -eq 1 ] || fail "banner duplicated on repeat run"
+grep -qF "not for production use" "$FIXTURE" || fail "banner content lost after repeat call"
 
 "$TOGGLE" "$FIXTURE" "2.9.0"
 [ "$(grep -c -F "$MARKER_START" "$FIXTURE")" -eq 0 ] || fail "banner not removed for GA version"
+! grep -qF "not for production use" "$FIXTURE" || fail "banner content not removed for GA version"
 
 grep -qF "JavaScript SDK intro text." "$FIXTURE" || fail "original README content lost"
 


### PR DESCRIPTION
## Summary
Adds a standard beta/pre-release disclaimer banner to the README, automatically toggled in and out by the existing release automation — part of the CUST-4287 RCA follow-up ([SK-2977](https://skyflow.atlassian.net/browse/SK-2977)). CUST-4287 was specifically a beta skyflow-js build reaching a customer's Production environment, so this repo is the direct root-cause fix.

- `scripts/toggle_beta_banner.sh` inserts the banner right after the README's title when the version being released is a `-beta.N` pre-release, and removes it on GA releases. Idempotent.
- Wired into `scripts/bump_version.sh` (public/beta path only — internal/dev builds are unaffected) and `common-release.yml` now stages `README.md` in its existing commit step.
- `scripts/toggle_beta_banner.test.sh` covers insertion, idempotency, GA removal, and content preservation (asserts the actual banner text, not just marker presence).

This is one of 8 sibling PRs (android, iOS, js, node, python, react-js, react-native, java) rolling out the same disclaimer text and mechanism across the SDKs. skyflow-go is deferred to a follow-up (no release CI to hook into today).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[SK-2977]: https://skyflow.atlassian.net/browse/SK-2977?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ